### PR TITLE
Fix not to spawn Goroutines when watch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @hyangtack @minwoox @trustin
+

--- a/dogma.go
+++ b/dogma.go
@@ -390,7 +390,7 @@ func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision s
 // WatchFile awaits and returns the query result of the specified file since the specified last known revision.
 func (c *Client) WatchFile(ctx context.Context, projectName, repoName, lastKnownRevision string,
 	query *Query, timeout time.Duration) <-chan *WatchResult {
-	watchResult := make(chan *WatchResult)
+	watchResult := make(chan *WatchResult, 1)
 	go func() {
 		watchResult <- c.watch.watchFile(ctx, projectName, repoName, lastKnownRevision, query, timeout)
 	}()
@@ -400,7 +400,7 @@ func (c *Client) WatchFile(ctx context.Context, projectName, repoName, lastKnown
 // WatchRepository awaits and returns the latest known revision since the specified revision.
 func (c *Client) WatchRepository(ctx context.Context,
 	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) <-chan *WatchResult {
-	watchResult := make(chan *WatchResult)
+	watchResult := make(chan *WatchResult, 1)
 	go func() {
 		watchResult <- c.watch.watchRepo(ctx, projectName, repoName, lastKnownRevision,
 			pathPattern, timeout)

--- a/dogma.go
+++ b/dogma.go
@@ -390,13 +390,22 @@ func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision s
 // WatchFile awaits and returns the query result of the specified file since the specified last known revision.
 func (c *Client) WatchFile(ctx context.Context, projectName, repoName, lastKnownRevision string,
 	query *Query, timeout time.Duration) <-chan *WatchResult {
-	return c.watch.watchFile(ctx, projectName, repoName, lastKnownRevision, query, timeout)
+	watchResult := make(chan *WatchResult)
+	go func() {
+		watchResult <- c.watch.watchFile(ctx, projectName, repoName, lastKnownRevision, query, timeout)
+	}()
+	return watchResult
 }
 
 // WatchRepository awaits and returns the latest known revision since the specified revision.
 func (c *Client) WatchRepository(ctx context.Context,
 	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) <-chan *WatchResult {
-	return c.watch.watchRepo(ctx, projectName, repoName, lastKnownRevision, pathPattern, timeout)
+	watchResult := make(chan *WatchResult)
+	go func() {
+		watchResult <- c.watch.watchRepo(ctx, projectName, repoName, lastKnownRevision,
+			pathPattern, timeout)
+	}()
+	return watchResult
 }
 
 //FileWatcher returns a Watcher which notifies its listeners when the result of the given Query becomes


### PR DESCRIPTION
Motivation:
Currently, Go client is spawning Goroutines every time it sends a new watch request to the server.
This can cause a problem by creating a lot of garbage Goroutines when the watch timeout is short.

Modification:
- Make a Goroutine watches the file

miscellaneous:
- Add CODEOWNERS

Result:
- Less garbages