### PR TITLE
Patching for Watcher and http client

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -7,7 +7,7 @@ import (
 var (
 	ErrLatestNotSet = fmt.Errorf("latest is not set yet")
 
-	ErrQueryShouldSet = fmt.Errorf("query should not be nil")
+	ErrQueryMustBeSet = fmt.Errorf("query should not be nil")
 
-	ErrWatcherIsClosed = fmt.Errorf("watcher is closed")
+	ErrWatcherClosed = fmt.Errorf("watcher is closed")
 )

--- a/consts.go
+++ b/consts.go
@@ -5,12 +5,9 @@ import (
 )
 
 var (
-	// ErrLatestNotSet latest not set
 	ErrLatestNotSet = fmt.Errorf("latest is not set yet")
 
-	// ErrQueryShouldSet indicates nil query
 	ErrQueryShouldSet = fmt.Errorf("query should not be nil")
 
-	// ErrWatcherIsClosed indicates watcher is closed
 	ErrWatcherIsClosed = fmt.Errorf("watcher is closed")
 )

--- a/consts.go
+++ b/consts.go
@@ -1,0 +1,16 @@
+package centraldogma
+
+import (
+	"fmt"
+)
+
+var (
+	// ErrLatestNotSet latest not set
+	ErrLatestNotSet = fmt.Errorf("latest is not set yet")
+
+	// ErrQueryShouldSet indicates nil query
+	ErrQueryShouldSet = fmt.Errorf("query should not be nil")
+
+	// ErrWatcherIsClosed indicates watcher is closed
+	ErrWatcherIsClosed = fmt.Errorf("watcher is closed")
+)

--- a/dogma.go
+++ b/dogma.go
@@ -218,7 +218,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 		return nil, err
 	}
 	defer func() {
-		// drain upto 512 bytes and close the body to reuse connection
+		// drain up 512 bytes and close the body to reuse connection
 		// see also:
 		// - https://github.com/google/go-github/pull/317
 		// - https://forum.golangbridge.org/t/do-i-need-to-read-the-body-before-close-it/5594/4

--- a/dogma.go
+++ b/dogma.go
@@ -40,6 +40,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -47,7 +48,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
-	"io/ioutil"
 )
 
 var log = logrus.New()
@@ -215,37 +215,34 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 
 	res, err := c.client.Do(req)
 	if err != nil {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-
 		return nil, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		errorMessage := &errorMessage{}
-		data, err := ioutil.ReadAll(res.Body)
-		if err == nil && data != nil {
-			json.Unmarshal(data, errorMessage)
-			if len(errorMessage.Message) != 0 {
-				err = fmt.Errorf("%s (status: %v)", errorMessage.Message, res.StatusCode)
-			} else {
-				err = fmt.Errorf("status: %v", res.StatusCode)
-			}
-		} else {
+
+		err = json.NewDecoder(res.Body).Decode(errorMessage) // no need to drain up
+		if err != nil {
 			err = fmt.Errorf("status: %v", res.StatusCode)
+		} else {
+			err = fmt.Errorf("%s (status: %v)", errorMessage.Message, res.StatusCode)
 		}
+
 		return res, err
 	}
 
 	if resContent != nil {
-		err = json.NewDecoder(res.Body).Decode(resContent)
-		if err == io.EOF { // empty response body
+		err = json.NewDecoder(res.Body).Decode(resContent) // no need to drain up
+		if err == io.EOF {                                 // empty response body
 			err = nil
 		}
+	} else {
+		// drain upto 512 bytes and close the body to reuse connection
+		// see also:
+		// - https://github.com/google/go-github/pull/317
+		// - https://forum.golangbridge.org/t/do-i-need-to-read-the-body-before-close-it/5594/4
+		io.CopyN(ioutil.Discard, res.Body, 512)
 	}
 
 	return res, err

--- a/dogma_util.go
+++ b/dogma_util.go
@@ -28,6 +28,10 @@ const (
 	maxInt63       = int64(^uint64(0) >> 1)
 )
 
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
 func nextDelay(numAttemptsSoFar int) time.Duration {
 	var nextDelay time.Duration
 	if numAttemptsSoFar == 1 {
@@ -46,20 +50,17 @@ func nextDelay(numAttemptsSoFar int) time.Duration {
 	random := random(bound)
 	result := saturatedAdd(minJitter, random)
 	if result < 0 {
-		return 0
-	} else {
-		return time.Duration(result)
+		result = 0
 	}
+	return time.Duration(result)
 }
 
 func saturatedMultiply(left time.Duration, right float64) time.Duration {
 	result := float64(left) * right
-
 	if result > float64(maxInt63) {
 		return time.Duration(maxInt63)
-	} else {
-		return time.Duration(result)
 	}
+	return time.Duration(result)
 }
 
 func random(bound int64) int64 {

--- a/watch_service.go
+++ b/watch_service.go
@@ -16,9 +16,7 @@ package centraldogma
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -45,9 +43,13 @@ type commitWithEntry struct {
 
 func (ws *watchService) watchFile(ctx context.Context, projectName, repoName, lastKnownRevision string,
 	query *Query, timeout time.Duration) <-chan *WatchResult {
-	watchResult := make(chan *WatchResult)
+
+	// initialize watch result channel
+	watchResult := make(chan *WatchResult, 1)
+
+	// validate query
 	if query == nil {
-		watchResult <- &WatchResult{Err: errors.New("query should not be nil")}
+		watchResult <- &WatchResult{Err: ErrQueryShouldSet}
 		return watchResult
 	}
 
@@ -71,7 +73,9 @@ func (ws *watchService) watchFile(ctx context.Context, projectName, repoName, la
 
 func (ws *watchService) watchRepo(ctx context.Context,
 	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) <-chan *WatchResult {
-	watchResult := make(chan *WatchResult)
+
+	// initialize watch result channel
+	watchResult := make(chan *WatchResult, 1)
 
 	// Normalize pathPattern
 	if len(pathPattern) == 0 {
@@ -89,6 +93,8 @@ func (ws *watchService) watchRepo(ctx context.Context,
 
 func (ws *watchService) watchRequest(ctx context.Context, watchResult chan<- *WatchResult,
 	u, lastKnownRevision string, timeout time.Duration) {
+
+	// initialize request
 	req, err := ws.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		watchResult <- &WatchResult{Err: err}
@@ -103,15 +109,24 @@ func (ws *watchService) watchRequest(ctx context.Context, watchResult chan<- *Wa
 		req.Header.Set("prefer", fmt.Sprintf("wait=%v", timeout.Seconds()))
 	}
 
+	// TODO: worker pool for this task
 	go func() {
+		reqCtx, cancel := context.WithTimeout(ctx, timeout+time.Second) // wait more than server
+
 		commitWithEntry := new(commitWithEntry)
-		res, err := ws.client.do(ctx, req, commitWithEntry)
+		res, err := ws.client.do(reqCtx, req, commitWithEntry)
 		if err != nil {
-			watchResult <- &WatchResult{Res: res, Err: err}
+			if err == context.DeadlineExceeded {
+				watchResult <- &WatchResult{Res: res, Err: fmt.Errorf("watch request timeout: %.3f", timeout.Seconds())}
+			} else {
+				watchResult <- &WatchResult{Res: res, Err: err}
+			}
 		} else {
 			watchResult <- &WatchResult{Commit: commitWithEntry.Commit, Entry: commitWithEntry.Entry,
 				Res: res, Err: nil}
 		}
+
+		cancel()
 	}()
 }
 
@@ -124,16 +139,22 @@ const (
 	stopped
 )
 
+// WatchListener listen to watcher
+type WatchListener func(revision int, value interface{})
+
 // Watcher watches the changes of a repository or a file.
 type Watcher struct {
-	state               int32
+	state int32
+
 	initialValueCh      chan *Latest // channel whose buffer is 1.
 	isInitialValueChSet int32        // 0 is false, 1 is true
-	watchCTX            context.Context
-	watchCancelFunc     func()
+
+	watchCTX        context.Context
+	watchCancelFunc func()
+
 	latest              atomic.Value
-	updateListeners     []func(revision int, value interface{})
-	listenersMutex      *sync.Mutex
+	updateListenerChans []chan *Latest
+	listenersMutex      sync.RWMutex
 
 	doWatchFunc          func(lastKnownRevision int) <-chan *WatchResult
 	convertingResultFunc func(result *WatchResult) *Latest
@@ -141,6 +162,8 @@ type Watcher struct {
 	projectName string
 	repoName    string
 	pathPattern string
+
+	numAttemptsSoFar int
 }
 
 // Latest represents a holder of the latest known value and its Revision retrieved by Watcher.
@@ -151,13 +174,16 @@ type Latest struct {
 }
 
 func newWatcher(projectName, repoName, pathPattern string) *Watcher {
-	rand.Seed(time.Now().UTC().UnixNano())
 	watchCTX, watchCancelFunc := context.WithCancel(context.Background())
-	return &Watcher{state: initial, initialValueCh: make(chan *Latest, 1),
-		watchCTX: watchCTX, watchCancelFunc: watchCancelFunc,
-		listenersMutex: &sync.Mutex{},
-		projectName:    projectName,
-		repoName:       repoName, pathPattern: pathPattern}
+	return &Watcher{
+		state:           initial,
+		initialValueCh:  make(chan *Latest, 1),
+		watchCTX:        watchCTX,
+		watchCancelFunc: watchCancelFunc,
+		projectName:     projectName,
+		repoName:        repoName,
+		pathPattern:     pathPattern,
+	}
 }
 
 // AwaitInitialValue awaits for the initial value to be available.
@@ -168,7 +194,7 @@ func (w *Watcher) AwaitInitialValue() Latest {
 	return *latest
 }
 
-// AwaitInitialValue awaits for the initial value to be available during the specified timeout.
+// AwaitInitialValueWith awaits for the initial value to be available during the specified timeout.
 func (w *Watcher) AwaitInitialValueWith(timeout time.Duration) Latest {
 	select {
 	case latest := <-w.initialValueCh:
@@ -180,27 +206,33 @@ func (w *Watcher) AwaitInitialValueWith(timeout time.Duration) Latest {
 	}
 }
 
+func (w *Watcher) getLatest() (lt *Latest) {
+	loaded := w.latest.Load()
+	if loaded != nil {
+		lt, _ = loaded.(*Latest)
+	}
+	return
+}
+
 // Latest returns the latest Revision and value of WatchFile() or WatchRepository() result.
 func (w *Watcher) Latest() Latest {
-	latest := w.latest.Load()
+	latest := w.getLatest()
 	if latest != nil {
-		if l, ok := latest.(Latest); ok {
-			return l
-		}
+		return *latest
 	}
-	return Latest{Err: errors.New("latest is not set yet")}
+	return Latest{Err: ErrLatestNotSet}
 }
 
 // LatestValue returns the latest value of watchFile() or WatchRepository() result.
 func (w *Watcher) LatestValue() (interface{}, error) {
-	latest := w.Latest()
-	if latest.Err != nil {
-		return nil, latest.Err
+	latest := w.getLatest()
+	if latest != nil {
+		return latest.Value, latest.Err
 	}
-	return latest.Value, nil
+	return nil, ErrLatestNotSet
 }
 
-// LatestValue returns the latest value of watchFile() or WatchRepository() result. If it's not available, this
+// LatestValueOr returns the latest value of watchFile() or WatchRepository() result. If it's not available, this
 // returns the defaultValue.
 func (w *Watcher) LatestValueOr(defaultValue interface{}) interface{} {
 	latest := w.Latest()
@@ -213,7 +245,7 @@ func (w *Watcher) LatestValueOr(defaultValue interface{}) interface{} {
 // Close stops watching the file specified in the Query or the pathPattern in the repository.
 func (w *Watcher) Close() {
 	atomic.StoreInt32(&w.state, stopped)
-	latest := &Latest{Err: errors.New("watcher is closed")}
+	latest := &Latest{Err: ErrWatcherIsClosed}
 	if atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
 		// The initial latest was not set before. So write the value to initialValueCh as well.
 		w.initialValueCh <- latest
@@ -222,23 +254,31 @@ func (w *Watcher) Close() {
 }
 
 // Watch registers a func that will be invoked when the value of the watched entry becomes available or changes.
-func (w *Watcher) Watch(listener func(revision int, value interface{})) error {
+func (w *Watcher) Watch(listener WatchListener) error {
 	if listener == nil {
-		return errors.New("listener is nil")
+		return nil // do nothing
 	}
+
+	// check watcher is stopped
 	if w.isStopped() {
-		return errors.New("watcher is closed")
+		return ErrWatcherIsClosed
 	}
 
 	w.listenersMutex.Lock()
-	defer w.listenersMutex.Unlock()
-	w.updateListeners = append(w.updateListeners, listener)
+	ch := make(chan *Latest, 32)
+	w.updateListenerChans = append(w.updateListenerChans, ch)
+	w.listenersMutex.Unlock()
+
+	// start notifier which notify on update
+	go w.notifier(listener, ch)
 
 	if latest := w.Latest(); latest.Err == nil {
-		go func() {
-			// Perform initial notification so that the listener always gets the initial value.
-			listener(latest.Revision, latest.Value)
-		}()
+		select {
+		case <-w.watchCTX.Done():
+			return w.watchCTX.Err()
+
+		case ch <- &latest:
+		}
 	}
 
 	return nil
@@ -246,7 +286,7 @@ func (w *Watcher) Watch(listener func(revision int, value interface{})) error {
 
 func (ws *watchService) fileWatcher(projectName, repoName string, query *Query) (*Watcher, error) {
 	if query == nil {
-		return nil, errors.New("query should not be nil")
+		return nil, ErrQueryShouldSet
 	}
 
 	w := newWatcher(projectName, repoName, query.Path)
@@ -276,34 +316,8 @@ func (ws *watchService) repoWatcher(projectName, repoName, pathPattern string) (
 
 func (w *Watcher) start() {
 	if atomic.CompareAndSwapInt32(&w.state, initial, started) {
-		w.scheduleWatch(0)
+		go w.scheduleWatch()
 	}
-}
-
-func (w *Watcher) scheduleWatch(numAttemptsSoFar int) {
-	if w.isStopped() {
-		return
-	}
-
-	var delay time.Duration
-	if numAttemptsSoFar == 0 {
-		latest := w.Latest()
-		if latest.Err != nil {
-			delay = delayOnSuccess
-		} else {
-			delay = 0
-		}
-	} else {
-		delay = nextDelay(numAttemptsSoFar)
-	}
-
-	go func() {
-		select {
-		case <-w.watchCTX.Done():
-		case <-time.NewTimer(delay).C:
-			w.doWatch(numAttemptsSoFar)
-		}
-	}()
 }
 
 func (w *Watcher) isStopped() bool {
@@ -311,21 +325,40 @@ func (w *Watcher) isStopped() bool {
 	return state == stopped
 }
 
-func (w *Watcher) doWatch(numAttemptsSoFar int) {
+func (w *Watcher) scheduleWatch() {
+	if w.isStopped() {
+		return
+	}
+
+	for {
+		select {
+		case <-w.watchCTX.Done():
+			return
+
+		default:
+			w.doWatch()
+		}
+	}
+}
+
+func (w *Watcher) doWatch() {
 	if w.isStopped() {
 		return
 	}
 
 	var lastKnownRevision int
-	curLatest := w.Latest()
-	if curLatest.Revision == 0 {
+	curLatest := w.getLatest()
+	if curLatest == nil || curLatest.Revision == 0 {
 		lastKnownRevision = 1 // Init revision
 	} else {
 		lastKnownRevision = curLatest.Revision
 	}
 
 	select {
+
 	case <-w.watchCTX.Done():
+		return
+
 	case watchResult := <-w.doWatchFunc(lastKnownRevision):
 		if watchResult.Err != nil {
 			if watchResult.Err == context.Canceled {
@@ -334,7 +367,10 @@ func (w *Watcher) doWatch(numAttemptsSoFar int) {
 			}
 
 			log.Debug(watchResult.Err)
-			w.scheduleWatch(numAttemptsSoFar + 1)
+
+			// wait for next attempt
+			w.numAttemptsSoFar++
+			w.delay()
 			return
 		}
 
@@ -343,11 +379,34 @@ func (w *Watcher) doWatch(numAttemptsSoFar int) {
 			// The initial latest is set for the first time. So write the value to initialValueCh as well.
 			w.initialValueCh <- newLatest
 		}
-		w.latest.Store(*newLatest)
+
+		// store latest
+		w.latest.Store(newLatest)
+
+		// log latest revision
 		log.Debugf("Watcher noticed updated file: %s/%s%s, rev=%v",
 			w.projectName, w.repoName, w.pathPattern, newLatest.Revision)
+
+		// notify listener
 		w.notifyListeners()
-		w.scheduleWatch(0)
+
+		// wait for next attempt
+		w.numAttemptsSoFar = 0
+		w.delay()
+	}
+}
+
+func (w *Watcher) delay() {
+	var delay time.Duration
+
+	if w.numAttemptsSoFar == 0 {
+		delay = delayOnSuccess
+	} else {
+		delay = nextDelay(w.numAttemptsSoFar)
+	}
+
+	if delay > 0 {
+		time.Sleep(delay)
 	}
 }
 
@@ -358,14 +417,36 @@ func (w *Watcher) notifyListeners() {
 	}
 
 	latest := w.Latest()
-	w.listenersMutex.Lock()
-	listenersSnapshot := make([]func(revision int, value interface{}), len(w.updateListeners))
-	copy(listenersSnapshot, w.updateListeners)
-	w.listenersMutex.Unlock()
 
-	go func() {
-		for _, listener := range listenersSnapshot {
-			listener(latest.Revision, latest.Value)
+	w.listenersMutex.RLock()
+	listenerChanSnapshot := make([]chan *Latest, len(w.updateListenerChans))
+	copy(listenerChanSnapshot, w.updateListenerChans)
+	w.listenersMutex.RUnlock()
+
+	for _, listener := range listenerChanSnapshot {
+		select {
+		case <-w.watchCTX.Done():
+			return
+
+		case listener <- &latest:
 		}
-	}()
+	}
+}
+
+func (w *Watcher) notifier(listener WatchListener, ch <-chan *Latest) {
+	for {
+		select {
+		case <-w.watchCTX.Done():
+			return
+
+		case latest, ok := <-ch:
+			if !ok { // channel is closed
+				return
+			}
+
+			if latest != nil {
+				listener(latest.Revision, latest.Value)
+			}
+		}
+	}
 }

--- a/watch_service.go
+++ b/watch_service.go
@@ -139,7 +139,7 @@ const (
 	stopped
 )
 
-// WatchListener listen to watcher
+// WatchListener listens to watcher
 type WatchListener func(revision int, value interface{})
 
 // Watcher watches the changes of a repository or a file.

--- a/watch_service_test.go
+++ b/watch_service_test.go
@@ -125,8 +125,8 @@ func TestWatcher(t *testing.T) {
 	query := &Query{Path: "/a.json", Type: Identity}
 	fw, _ := c.FileWatcher("foo", "bar", query)
 
-	myCh1 := make(chan interface{})
-	myCh2 := make(chan interface{})
+	myCh1 := make(chan interface{}, 128)
+	myCh2 := make(chan interface{}, 128)
 	listener1 := func(revision int, value interface{}) { myCh1 <- value }
 	listener2 := func(revision int, value interface{}) { myCh2 <- value }
 
@@ -181,7 +181,7 @@ func TestWatcher_convertingValueFunc(t *testing.T) {
 	query := &Query{Path: "/a.json", Type: Identity}
 	fw, _ := c.FileWatcher("foo", "bar", query)
 
-	myCh := make(chan interface{})
+	myCh := make(chan interface{}, 128)
 	listener := func(revision int, value interface{}) { myCh <- value }
 	fw.Watch(listener)
 
@@ -218,14 +218,14 @@ func TestWatcher_closed_AwaitInitialValue(t *testing.T) {
 		t.Errorf("latest: %+v, want %+v", latest.Err, want)
 	}
 
-	done := make(chan bool)
+	done := make(chan struct{})
 	go func() {
 		latest := fw.AwaitInitialValue()
 		want := "watcher is closed"
 		if latest.Err.Error() != want {
 			t.Errorf("latest from AwaitInitialValue: %+v, want %+v", latest.Err, want)
 		}
-		done <- true
+		done <- struct{}{}
 	}()
 	fw.Close()
 	<-done
@@ -243,7 +243,7 @@ func TestWatcher_started_AwaitInitialValue(t *testing.T) {
 	query := &Query{Path: "/a.json", Type: Identity}
 	fw, _ := c.watch.fileWatcher("foo", "bar", query)
 
-	done := make(chan bool)
+	done := make(chan struct{})
 	go func() {
 		latest := fw.AwaitInitialValue()
 		want := 3
@@ -256,7 +256,7 @@ func TestWatcher_started_AwaitInitialValue(t *testing.T) {
 			t.Errorf("latest: %+v, want %+v", latest2, latest)
 		}
 
-		done <- true
+		done <- struct{}{}
 	}()
 	fw.start()
 	<-done
@@ -283,7 +283,7 @@ func TestRepoWatcher(t *testing.T) {
 
 	fw, _ := c.RepoWatcher("foo", "bar", "/**")
 
-	myCh := make(chan interface{})
+	myCh := make(chan interface{}, 128)
 	listener := func(revision int, value interface{}) { myCh <- value }
 	fw.Watch(listener)
 
@@ -325,7 +325,7 @@ func TestRepoWatcherInvalidPathPattern(t *testing.T) {
 	for _, pattern := range patterns {
 		fw, _ := c.RepoWatcher("foo", "bar", pattern)
 
-		myCh := make(chan interface{})
+		myCh := make(chan interface{}, 128)
 		listener := func(revision int, value interface{}) { myCh <- value }
 		fw.Watch(listener)
 


### PR DESCRIPTION
 - Fix go routine spawning by cycling call between scheduleWatch and doWatch
- Prevent spawning too much go routine to notify listener in case listener fail to catch up. This also prevents notifying >2 revisions at the same time (ambiguous order)
- Drain up response (in http client do) when server return malform data and expected response not set
- Refactor code