### PR TITLE
Fix internal app import

### DIFF
--- a/internal/app/dogma/go.mod
+++ b/internal/app/dogma/go.mod
@@ -3,8 +3,7 @@ module go.linecorp.com/centraldogma/internal/app/dogma
 require (
 	github.com/fhs/go-netrc v1.0.0
 	github.com/urfave/cli v1.20.0
-	go.linecorp.com/centraldogma v0.0.0-20181001092049-d6fea3344193
+	go.linecorp.com/centraldogma v0.0.0-20181129085633-1c98e8bf157d
 	golang.org/x/crypto v0.0.0-20180927165925-5295e8364332db77d75fce11f1d19c053919a9c9
+	golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 // indirect
 )
-
-replace go.linecorp.com/centraldogma => ../../..

--- a/internal/app/dogma/go.sum
+++ b/internal/app/dogma/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+go.linecorp.com/centraldogma v0.0.0-20181129085633-1c98e8bf157d h1:6OJCQUcIlPTeiPIvr/gblVLDX0q8+Hldu5Stwlg0auo=
+go.linecorp.com/centraldogma v0.0.0-20181129085633-1c98e8bf157d/go.mod h1:2oG/mC9W3NbCF7JlWjenR95+L7ZLBDMDrWsJGtLfTb0=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180927165925-5295e8364332db77d75fce11f1d19c053919a9c9 h1:RoVTPKzFSC3rQggDzW7rbrJsdZfZC/FbgZD2/Y3S7z8=
 golang.org/x/crypto v0.0.0-20180927165925-5295e8364332db77d75fce11f1d19c053919a9c9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -28,6 +30,8 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTu
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180928133829-e4b3c5e9061176387e7cea65e4dc5853801f3fb7 h1:aTPHLygF8PcW9eEip/Txo4Badb6KGEBfwTEqhdOrhS8=
 golang.org/x/sys v0.0.0-20180928133829-e4b3c5e9061176387e7cea65e4dc5853801f3fb7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 h1:YAFjXN64LMvktoUZH9zgY4lGc/msGN7HQfoSuKCgaDU=
+golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.2.0 h1:S0iUepdCWODXRvtE+gcRDd15L+k+k1AiHlMiMjefH24=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
1. Currently, internal app is trying to link to `line/centraldogma-go` (in go.mod):
```
replace go.linecorp.com/centraldogma => ../../..
```
If breaking change in api of `line/centraldogma-go`, internal app will fail to build: 
- CI still try to get latest code from line repo. 
- This code is not code from commit, linking to newer code which contains breaking change. The result is failure run/build.

2. We consider internal app a separate module which work independently with `line/centraldogma-go`. It's better to have it own dependencies version. 
New changes on `line/centraldogma-go` won't effect it because it hold a fixed version of `line/centraldogma-go`. User still able to download and build it.