### PR TITLE
Break change: new file/repo watching api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ env:
   global:
   - GO111MODULE=on
 go_import_path: go.linecorp.com/centraldogma
-install:
-- go get -v go.linecorp.com/centraldogma
-- go get -v go.linecorp.com/centraldogma/internal/app/dogma
 script:
-- go test -v -race -coverprofile=coverage.1.txt -covermode=atomic go.linecorp.com/centraldogma
-- go test -v -race -coverprofile=coverage.2.txt -covermode=atomic go.linecorp.com/centraldogma/internal/app/dogma
+- source=$GOPATH/src/go.linecorp.com/centraldogma
+- cd $source
+- go test -v -race -coverprofile=$source/coverage.1.txt -covermode=atomic
+- cd $source/internal/app/dogma
+- go test -v -race -coverprofile=$source/coverage.2.txt -covermode=atomic
+- cd $source
 - cat coverage.*.txt > coverage.txt
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ env:
   - GO111MODULE=on
 go_import_path: go.linecorp.com/centraldogma
 script:
-- source=$GOPATH/src/go.linecorp.com/centraldogma
-- cd $source
-- go test -v -race -coverprofile=$source/coverage.1.txt -covermode=atomic
-- cd $source/internal/app/dogma
-- go test -v -race -coverprofile=$source/coverage.2.txt -covermode=atomic
-- cd $source
+- SRCDIR=$GOPATH/src/go.linecorp.com/centraldogma
+- cd $SRCDIR
+- go test -v -race -coverprofile=$SRCDIR/coverage.1.txt -covermode=atomic
+- cd $SRCDIR/internal/app/dogma
+- go test -v -race -coverprofile=$SRCDIR/coverage.2.txt -covermode=atomic
+- cd $SRCDIR
 - cat coverage.*.txt > coverage.txt
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/consts.go
+++ b/consts.go
@@ -11,3 +11,7 @@ var (
 
 	ErrWatcherClosed = fmt.Errorf("watcher is closed")
 )
+
+const (
+	DefaultChannelBuffer = 128
+)

--- a/content_service.go
+++ b/content_service.go
@@ -86,7 +86,11 @@ type EntryContent []byte
 
 func (e *EntryContent) UnmarshalJSON(b []byte) error {
 	if n := len(b); n >= 2 && b[0] == 34 && b[n-1] == 34 { // string
-		*e = b[1 : n-1]
+		var dst string
+		if err := json.Unmarshal(b, &dst); err != nil {
+			return err
+		}
+		*e = []byte(dst)
 	} else {
 		*e = b
 	}

--- a/content_service.go
+++ b/content_service.go
@@ -46,12 +46,12 @@ const (
 
 // Entry represents an entry in the repository.
 type Entry struct {
-	Path       string      `json:"path"`
-	Type       EntryType   `json:"type"` // can be JSON, TEXT or DIRECTORY
-	Content    interface{} `json:"content,omitempty"`
-	Revision   string      `json:"revision,omitempty"`
-	URL        string      `json:"url,omitempty"`
-	ModifiedAt string      `json:"modifiedAt,omitempty"`
+	Path       string       `json:"path"`
+	Type       EntryType    `json:"type"` // can be JSON, TEXT or DIRECTORY
+	Content    EntryContent `json:"content,omitempty"`
+	Revision   string       `json:"revision,omitempty"`
+	URL        string       `json:"url,omitempty"`
+	ModifiedAt string       `json:"modifiedAt,omitempty"`
 }
 
 func (c *Entry) MarshalJSON() ([]byte, error) {
@@ -81,6 +81,18 @@ func (c *Entry) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// EntryContent represents content of an entry
+type EntryContent []byte
+
+func (e *EntryContent) UnmarshalJSON(b []byte) error {
+	if n := len(b); n >= 2 && b[0] == 34 && b[n-1] == 34 { // string
+		*e = b[1 : n-1]
+	} else {
+		*e = b
+	}
+	return nil
+}
+
 // PushResult represents a result of push in the repository.
 type PushResult struct {
 	Revision int    `json:"revision"`
@@ -89,10 +101,10 @@ type PushResult struct {
 
 // Commit represents a commit in the repository.
 type Commit struct {
-	Revision      int            `json:"revision"`
-	Author        *Author        `json:"author"`
-	CommitMessage *CommitMessage `json:"commitMessage,omitempty"`
-	PushedAt      string         `json:"pushedAt,omitempty"`
+	Revision      int           `json:"revision"`
+	Author        Author        `json:"author,omitempty"`
+	CommitMessage CommitMessage `json:"commitMessage,omitempty"`
+	PushedAt      string        `json:"pushedAt,omitempty"`
 }
 
 // CommitMessages represents a commit message in the repository.

--- a/content_service.go
+++ b/content_service.go
@@ -81,7 +81,7 @@ func (c *Entry) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// EntryContent represents content of an entry
+// EntryContent represents the content of an entry
 type EntryContent []byte
 
 func (e *EntryContent) UnmarshalJSON(b []byte) error {

--- a/content_service_test.go
+++ b/content_service_test.go
@@ -68,7 +68,7 @@ func TestGetFile(t *testing.T) {
 
 	query := &Query{Path: "/b.txt", Type: Identity}
 	entry, _, _ := c.GetFile(context.Background(), "foo", "bar", "", query)
-	want := &Entry{Path: "/b.txt", Type: Text, Content: "hello world~!"}
+	want := &Entry{Path: "/b.txt", Type: Text, Content: EntryContent("hello world~!")}
 	if !reflect.DeepEqual(entry, want) {
 		t.Errorf("GetFile returned %+v, want %+v", entry, want)
 	}
@@ -86,7 +86,7 @@ func TestGetFile_JSON(t *testing.T) {
 
 	query := &Query{Path: "/a.json", Type: Identity}
 	entry, _, _ := c.GetFile(context.Background(), "foo", "bar", "", query)
-	want := &Entry{Path: "/a.json", Type: JSON, Content: map[string]interface{}{"a": "b"}}
+	want := &Entry{Path: "/a.json", Type: JSON, Content: EntryContent(`{"a":"b"}`)}
 	if !reflect.DeepEqual(entry, want) {
 		t.Errorf("GetFile returned %+v, want %+v", entry, want)
 	}
@@ -105,7 +105,7 @@ func TestGetFile_WithJSONPath(t *testing.T) {
 
 	query := &Query{Path: "/a.json", Type: JSONPath, Expressions: []string{"$.a"}}
 	entry, _, _ := c.GetFile(context.Background(), "foo", "bar", "", query)
-	want := &Entry{Path: "/a.json", Type: JSON, Content: "b"}
+	want := &Entry{Path: "/a.json", Type: JSON, Content: EntryContent("b")}
 	if !reflect.DeepEqual(entry, want) {
 		t.Errorf("GetFile returned %+v, want %+v", entry, want)
 	}
@@ -120,12 +120,12 @@ func TestGetFile_WithJSONPathAndRevision(t *testing.T) {
 			testMethod(t, r, http.MethodGet)
 			testURLQuery(t, r, "jsonpath", "$.a")
 			testURLQuery(t, r, "revision", "-1")
-			fmt.Fprint(w, `{"path":"/a.json", "type":"JSON", "content":"b"}`)
+			fmt.Fprint(w, `{"path":"/a.json", "type":"JSON", "content":    "b"}`)
 		})
 
 	query := &Query{Path: "/a.json", Type: JSONPath, Expressions: []string{"$.a"}}
 	entry, _, _ := c.GetFile(context.Background(), "foo", "bar", "-1", query)
-	want := &Entry{Path: "/a.json", Type: JSON, Content: "b"}
+	want := &Entry{Path: "/a.json", Type: JSON, Content: EntryContent(`b`)}
 	if !reflect.DeepEqual(entry, want) {
 		t.Errorf("GetFile returned %+v, want %+v", entry, want)
 	}
@@ -142,8 +142,10 @@ func TestGetFiles(t *testing.T) {
 	})
 
 	entries, _, _ := c.GetFiles(context.Background(), "foo", "bar", "", "/**")
-	want := []*Entry{{Path: "/a.json", Type: JSON, Content: map[string]interface{}{"a": "b"}},
-		{Path: "/b.txt", Type: Text, Content: "hello world~!"}}
+	want := []*Entry{
+		{Path: "/a.json", Type: JSON, Content: EntryContent(`{"a":"b"}`)},
+		{Path: "/b.txt", Type: Text, Content: EntryContent(`hello world~!`)},
+	}
 	if !reflect.DeepEqual(entries, want) {
 		t.Errorf("GetFiles returned %+v, want %+v", entries, want)
 	}
@@ -166,10 +168,10 @@ func TestGetHistory(t *testing.T) {
 
 	history, _, _ := c.GetHistory(context.Background(), "foo", "bar", "-2", "-1", "/**", 2)
 	want := []*Commit{
-		{Revision: 1, Author: &Author{Name: "minux", Email: "minux@m.x"},
-			CommitMessage: &CommitMessage{Summary: "Add a.json"}},
-		{Revision: 2, Author: &Author{Name: "minux", Email: "minux@m.x"},
-			CommitMessage: &CommitMessage{Summary: "Edit a.json"}}}
+		{Revision: 1, Author: Author{Name: "minux", Email: "minux@m.x"},
+			CommitMessage: CommitMessage{Summary: "Add a.json"}},
+		{Revision: 2, Author: Author{Name: "minux", Email: "minux@m.x"},
+			CommitMessage: CommitMessage{Summary: "Edit a.json"}}}
 	if !reflect.DeepEqual(history, want) {
 		t.Errorf("GetHistory returned %+v, want %+v", history, want)
 	}

--- a/dogma.go
+++ b/dogma.go
@@ -404,13 +404,39 @@ func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer
 }
 
 // WatchFile watches on file changes. The watched result will be returned
-// through the returned channel. The api also provides manual closer to stop watching
+// through the returned channel. The API also provides a manual closer to stop watching
 // and release underlying resources.
 // In short, watching will be stopped in case either context is cancelled or closer is
 // called.
 // Manually closing returned channel is unsafe and may cause sending on closed channel error.
-func (c *Client) WatchFile(ctx context.Context, projectName, repoName string,
-	query *Query, timeout time.Duration) (result <-chan WatchResult, closer func(), err error) {
+// Usage:
+//
+//    query := &Query{Path: "/a.json", Type: Identity}
+//    ctx := context.Background()
+//    changes, closer, err := client.WatchFile(ctx, "foo", "bar", query, 2 * time.Second)
+//    if err != nil {
+//		 panic(err)
+//    }
+//    defer closer() // stop watching and release underlying resources.
+//
+//    /* close(changes) */ // manually closing is unsafe, don't do this.
+//
+//    for {
+//        select {
+//  		case <-ctx.Done():
+//				...
+//
+//			case change := <-changes:
+//             // got change
+//             json.Unmarshal(change.Entry.Content, &expect)
+//             ...
+//        }
+//    }
+func (c *Client) WatchFile(
+	ctx context.Context,
+	projectName, repoName string, query *Query,
+	timeout time.Duration,
+) (result <-chan WatchResult, closer func(), err error) {
 
 	var w *Watcher
 
@@ -425,13 +451,39 @@ func (c *Client) WatchFile(ctx context.Context, projectName, repoName string,
 }
 
 // WatchRepository watches on repository changes. The watched result will be returned
-// through the returned channel. The api also provides manual closer to stop watching
+// through the returned channel. The API also provides a manual closer to stop watching
 // and release underlying resources.
 // In short, watching will be stopped in case either context is cancelled or closer is
 // called.
 // Manually closing returned channel is unsafe and may cause sending on closed channel error.
-func (c *Client) WatchRepository(ctx context.Context,
-	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) (result <-chan WatchResult, closer func(), err error) {
+// Usage:
+//
+//    query := &Query{Path: "/a.json", Type: Identity}
+//    ctx := context.Background()
+//    changes, closer, err := client.WatchRepository(ctx, "foo", "bar", "/*.json", 2 * time.Second)
+//    if err != nil {
+//		 panic(err)
+//    }
+//    defer closer() // stop watching and release underlying resources.
+//
+//    /* close(changes) */ // manually closing is unsafe, don't do this.
+//
+//    for {
+//        select {
+//  		case <-ctx.Done():
+//				...
+//
+//			case change := <-changes:
+//             // got change
+//             json.Unmarshal(change.Entry.Content, &expect)
+//             ...
+//        }
+//    }
+func (c *Client) WatchRepository(
+	ctx context.Context,
+	projectName, repoName, pathPattern string,
+	timeout time.Duration,
+) (result <-chan WatchResult, closer func(), err error) {
 
 	var w *Watcher
 

--- a/dogma.go
+++ b/dogma.go
@@ -385,20 +385,68 @@ func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision s
 	return c.content.push(ctx, projectName, repoName, baseRevision, commitMessage, changes)
 }
 
-// WatchFile awaits and returns the query result of the specified file since the specified last known revision.
-func (c *Client) WatchFile(ctx context.Context, projectName, repoName, lastKnownRevision string,
-	query *Query, timeout time.Duration) <-chan *WatchResult {
-	return c.watch.watchFile(ctx, projectName, repoName, lastKnownRevision, query, timeout)
+func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer func()) {
+	// setup watching channel
+	ch := make(chan WatchResult, DefaultChannelBuffer)
+	result = ch
+	w.Watch(func(value WatchResult) {
+		ch <- value
+	})
+
+	// setup closer
+	closer = func() {
+		w.Close()
+	}
+
+	// start watching
+	w.start()
+	return
 }
 
-// WatchRepository awaits and returns the latest known revision since the specified revision.
+// WatchFile watches on file changes. The watched result will be returned
+// through the returned channel. The api also provides manual closer to stop watching
+// and release underlying resources.
+// In short, watching will be stopped in case either context is cancelled or closer is
+// called.
+// Manually closing returned channel is unsafe and may cause sending on closed channel error.
+func (c *Client) WatchFile(ctx context.Context, projectName, repoName string,
+	query *Query, timeout time.Duration) (result <-chan WatchResult, closer func(), err error) {
+
+	var w *Watcher
+
+	// initialize watcher
+	w, err = c.watch.fileWatcherWithTimeout(ctx, projectName, repoName, query, timeout)
+	if err != nil {
+		return
+	}
+
+	result, closer = c.watchWithWatcher(w)
+	return
+}
+
+// WatchRepository watches on repository changes. The watched result will be returned
+// through the returned channel. The api also provides manual closer to stop watching
+// and release underlying resources.
+// In short, watching will be stopped in case either context is cancelled or closer is
+// called.
+// Manually closing returned channel is unsafe and may cause sending on closed channel error.
 func (c *Client) WatchRepository(ctx context.Context,
-	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) <-chan *WatchResult {
-	return c.watch.watchRepo(ctx, projectName, repoName, lastKnownRevision, pathPattern, timeout)
+	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) (result <-chan WatchResult, closer func(), err error) {
+
+	var w *Watcher
+
+	// initialize watcher
+	w, err = c.watch.repoWatcherWithTimeout(ctx, projectName, repoName, pathPattern, timeout)
+	if err != nil {
+		return
+	}
+
+	result, closer = c.watchWithWatcher(w)
+	return
 }
 
-//FileWatcher returns a Watcher which notifies its listeners when the result of the given Query becomes
-//available or changes. For example:
+// FileWatcher returns a Watcher which notifies its listeners when the result of the given Query becomes
+// available or changes. For example:
 //
 //    query := &Query{Path: "/a.json", Type: Identity}
 //    watcher := client.FileWatcher("foo", "bar", query)
@@ -409,7 +457,7 @@ func (c *Client) WatchRepository(ctx context.Context,
 //    })
 //    myValue := <-myCh
 func (c *Client) FileWatcher(projectName, repoName string, query *Query) (*Watcher, error) {
-	fw, err := c.watch.fileWatcher(projectName, repoName, query)
+	fw, err := c.watch.fileWatcher(context.Background(), projectName, repoName, query)
 	if err != nil {
 		return nil, err
 	}
@@ -417,8 +465,8 @@ func (c *Client) FileWatcher(projectName, repoName string, query *Query) (*Watch
 	return fw, nil
 }
 
-//RepoWatcher returns a Watcher which notifies its listeners when the repository that matched the given
-//pathPattern becomes available or changes. For example:
+// RepoWatcher returns a Watcher which notifies its listeners when the repository that matched the given
+// pathPattern becomes available or changes. For example:
 //
 //    watcher := client.RepoWatcher("foo", "bar", "/*.json")
 //
@@ -428,7 +476,7 @@ func (c *Client) FileWatcher(projectName, repoName string, query *Query) (*Watch
 //    })
 //    myValue := <-myCh
 func (c *Client) RepoWatcher(projectName, repoName, pathPattern string) (*Watcher, error) {
-	rw, err := c.watch.repoWatcher(projectName, repoName, pathPattern)
+	rw, err := c.watch.repoWatcher(context.Background(), projectName, repoName, pathPattern)
 	if err != nil {
 		return nil, err
 	}

--- a/dogma.go
+++ b/dogma.go
@@ -423,10 +423,10 @@ func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer
 //
 //    for {
 //        select {
-//  		case <-ctx.Done():
-//				...
+//          case <-ctx.Done():
+//             ...
 //
-//			case change := <-changes:
+//          case change := <-changes:
 //             // got change
 //             json.Unmarshal(change.Entry.Content, &expect)
 //             ...
@@ -470,10 +470,10 @@ func (c *Client) WatchFile(
 //
 //    for {
 //        select {
-//  		case <-ctx.Done():
-//				...
+//          case <-ctx.Done():
+//             ...
 //
-//			case change := <-changes:
+//          case change := <-changes:
 //             // got change
 //             json.Unmarshal(change.Entry.Content, &expect)
 //             ...

--- a/dogma.go
+++ b/dogma.go
@@ -413,7 +413,7 @@ func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer
 //
 //    query := &Query{Path: "/a.json", Type: Identity}
 //    ctx := context.Background()
-//    changes, closer, err := client.WatchFile(ctx, "foo", "bar", query, 2 * time.Second)
+//    changes, closer, err := client.WatchFile(ctx, "foo", "bar", query, 2 * time.Minute)
 //    if err != nil {
 //		 panic(err)
 //    }
@@ -460,7 +460,7 @@ func (c *Client) WatchFile(
 //
 //    query := &Query{Path: "/a.json", Type: Identity}
 //    ctx := context.Background()
-//    changes, closer, err := client.WatchRepository(ctx, "foo", "bar", "/*.json", 2 * time.Second)
+//    changes, closer, err := client.WatchRepository(ctx, "foo", "bar", "/*.json", 2 * time.Minute)
 //    if err != nil {
 //		 panic(err)
 //    }

--- a/project_service.go
+++ b/project_service.go
@@ -23,10 +23,10 @@ type projectService service
 
 // Project represents a project in the Central Dogma server.
 type Project struct {
-	Name      string  `json:"name"`
-	Creator   *Author `json:"creator,omitempty"`
-	URL       string  `json:"url,omitempty"`
-	CreatedAt string  `json:"createdAt,omitempty"`
+	Name      string `json:"name"`
+	Creator   Author `json:"creator,omitempty"`
+	URL       string `json:"url,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
 }
 
 type Author struct {

--- a/project_service_test.go
+++ b/project_service_test.go
@@ -46,7 +46,7 @@ func TestCreateProject(t *testing.T) {
 	project, res, _ := c.CreateProject(context.Background(), input.Name)
 	testStatus(t, res, 201)
 
-	want := &Project{Name: "foo", Creator: &Author{Name: "minux", Email: "minux@m.x"}}
+	want := &Project{Name: "foo", Creator: Author{Name: "minux", Email: "minux@m.x"}}
 	if !reflect.DeepEqual(project, want) {
 		t.Errorf("CreateProject returned %+v, want %+v", project, want)
 	}
@@ -79,7 +79,7 @@ func TestUnremoveProject(t *testing.T) {
 
 	project, _, _ := c.UnremoveProject(context.Background(), "foo")
 
-	want := &Project{Name: "foo", Creator: &Author{Name: "minux", Email: "minux@m.x"}, URL: "/api/v1/projects/foo"}
+	want := &Project{Name: "foo", Creator: Author{Name: "minux", Email: "minux@m.x"}, URL: "/api/v1/projects/foo"}
 	if !reflect.DeepEqual(project, want) {
 		t.Errorf("UnremoveProject returned %+v, want %+v", project, want)
 	}
@@ -98,8 +98,8 @@ func TestListProject(t *testing.T) {
 
 	projects, _, _ := c.ListProjects(context.Background())
 	want := []*Project{
-		{Name: "foo", Creator: &Author{Name: "minux", Email: "minux@m.x"}, URL: "/api/v1/projects/foo"},
-		{Name: "bar", Creator: &Author{Name: "minux", Email: "minux@m.x"}, URL: "/api/v1/projects/bar"}}
+		{Name: "foo", Creator: Author{Name: "minux", Email: "minux@m.x"}, URL: "/api/v1/projects/foo"},
+		{Name: "bar", Creator: Author{Name: "minux", Email: "minux@m.x"}, URL: "/api/v1/projects/bar"}}
 	if !reflect.DeepEqual(projects, want) {
 		t.Errorf("ListProjects returned %+v, want %+v", projects, want)
 	}

--- a/watch_service.go
+++ b/watch_service.go
@@ -94,7 +94,8 @@ func (ws *watchService) watchRepo(
 func (ws *watchService) watchRequest(
 	ctx context.Context,
 	u, lastKnownRevision string,
-	timeout time.Duration) *WatchResult {
+	timeout time.Duration,
+) *WatchResult {
 
 	// initialize request
 	req, err := ws.client.newRequest(http.MethodGet, u, nil)
@@ -258,11 +259,18 @@ func (w *Watcher) Watch(listener WatchListener) error {
 	return nil
 }
 
-func (ws *watchService) fileWatcher(ctx context.Context, projectName, repoName string, query *Query) (*Watcher, error) {
+func (ws *watchService) fileWatcher(
+	ctx context.Context,
+	projectName, repoName string, query *Query,
+) (*Watcher, error) {
 	return ws.fileWatcherWithTimeout(ctx, projectName, repoName, query, defaultWatchTimeout)
 }
 
-func (ws *watchService) fileWatcherWithTimeout(ctx context.Context, projectName, repoName string, query *Query, timeout time.Duration) (*Watcher, error) {
+func (ws *watchService) fileWatcherWithTimeout(
+	ctx context.Context,
+	projectName, repoName string, query *Query,
+	timeout time.Duration,
+) (*Watcher, error) {
 	if query == nil {
 		return nil, ErrQueryMustBeSet
 	}
@@ -275,11 +283,18 @@ func (ws *watchService) fileWatcherWithTimeout(ctx context.Context, projectName,
 	return w, nil
 }
 
-func (ws *watchService) repoWatcher(ctx context.Context, projectName, repoName, pathPattern string) (*Watcher, error) {
+func (ws *watchService) repoWatcher(
+	ctx context.Context,
+	projectName, repoName, pathPattern string,
+) (*Watcher, error) {
 	return ws.repoWatcherWithTimeout(ctx, projectName, repoName, pathPattern, defaultWatchTimeout)
 }
 
-func (ws *watchService) repoWatcherWithTimeout(ctx context.Context, projectName, repoName, pathPattern string, timeout time.Duration) (*Watcher, error) {
+func (ws *watchService) repoWatcherWithTimeout(
+	ctx context.Context,
+	projectName, repoName, pathPattern string,
+	timeout time.Duration,
+) (*Watcher, error) {
 	w := newWatcher(ctx, projectName, repoName, pathPattern)
 	w.doWatchFunc = func(ctx context.Context, lastKnownRevision int) *WatchResult {
 		return ws.watchRepo(ctx, projectName, repoName, strconv.Itoa(lastKnownRevision),
@@ -323,7 +338,7 @@ func (w *Watcher) doWatch() {
 	var lastKnownRevision int
 	curLatest := w.getLatest()
 	if curLatest == nil || curLatest.Commit.Revision == 0 {
-		lastKnownRevision = -1 // Init revision
+		lastKnownRevision = 1 // Init revision
 	} else {
 		lastKnownRevision = curLatest.Commit.Revision
 	}

--- a/watch_service.go
+++ b/watch_service.go
@@ -142,7 +142,7 @@ const (
 )
 
 // WatchListener listens to Watcher.
-type WatchListener func(v WatchResult)
+type WatchListener func(result WatchResult)
 
 // Watcher watches the changes of a repository or a file.
 type Watcher struct {

--- a/watch_service.go
+++ b/watch_service.go
@@ -30,27 +30,27 @@ type watchService service
 
 // WatchResult represents a result from watch operation.
 type WatchResult struct {
-	Commit *Commit
-	Entry  *Entry
+	Commit Commit
+	Entry  Entry
 	Res    *http.Response
 	Err    error
 }
 
 type commitWithEntry struct {
-	*Commit
-	Entry *Entry `json:"entry,omitempty"`
+	Commit
+	Entry Entry `json:"entry,omitempty"`
 }
 
-func (ws *watchService) watchFile(ctx context.Context, projectName, repoName, lastKnownRevision string,
-	query *Query, timeout time.Duration) <-chan *WatchResult {
-
-	// initialize watch result channel
-	watchResult := make(chan *WatchResult, 1)
+func (ws *watchService) watchFile(
+	ctx context.Context,
+	projectName, repoName, lastKnownRevision string,
+	query *Query,
+	timeout time.Duration,
+) *WatchResult {
 
 	// validate query
 	if query == nil {
-		watchResult <- &WatchResult{Err: ErrQueryMustBeSet}
-		return watchResult
+		return &WatchResult{Err: ErrQueryMustBeSet}
 	}
 
 	// Normalize query path when it does not start with "/".
@@ -62,20 +62,20 @@ func (ws *watchService) watchFile(ctx context.Context, projectName, repoName, la
 	v := &url.Values{}
 	if query != nil && query.Type == JSONPath {
 		if err := setJSONPaths(v, query.Path, query.Expressions); err != nil {
-			watchResult <- &WatchResult{Err: err}
-			return watchResult
+			return &WatchResult{Err: err}
 		}
 	}
 	u += encodeValues(v)
-	ws.watchRequest(ctx, watchResult, u, lastKnownRevision, timeout)
-	return watchResult
+
+	return ws.watchRequest(ctx, u, lastKnownRevision, timeout)
 }
 
-func (ws *watchService) watchRepo(ctx context.Context,
-	projectName, repoName, lastKnownRevision, pathPattern string, timeout time.Duration) <-chan *WatchResult {
-
-	// initialize watch result channel
-	watchResult := make(chan *WatchResult, 1)
+func (ws *watchService) watchRepo(
+	ctx context.Context,
+	projectName, repoName, lastKnownRevision,
+	pathPattern string,
+	timeout time.Duration,
+) *WatchResult {
 
 	// Normalize pathPattern
 	if len(pathPattern) == 0 {
@@ -87,18 +87,19 @@ func (ws *watchService) watchRepo(ctx context.Context,
 	}
 
 	u := fmt.Sprintf("%vprojects/%v/repos/%v/contents%v", defaultPathPrefix, projectName, repoName, pathPattern)
-	ws.watchRequest(ctx, watchResult, u, lastKnownRevision, timeout)
-	return watchResult
+
+	return ws.watchRequest(ctx, u, lastKnownRevision, timeout)
 }
 
-func (ws *watchService) watchRequest(ctx context.Context, watchResult chan<- *WatchResult,
-	u, lastKnownRevision string, timeout time.Duration) {
+func (ws *watchService) watchRequest(
+	ctx context.Context,
+	u, lastKnownRevision string,
+	timeout time.Duration) *WatchResult {
 
 	// initialize request
 	req, err := ws.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
-		watchResult <- &WatchResult{Err: err}
-		return
+		return &WatchResult{Err: err}
 	}
 	if len(lastKnownRevision) != 0 {
 		req.Header.Set("if-none-match", lastKnownRevision)
@@ -109,28 +110,28 @@ func (ws *watchService) watchRequest(ctx context.Context, watchResult chan<- *Wa
 		req.Header.Set("prefer", fmt.Sprintf("wait=%v", timeout.Seconds()))
 	}
 
-	// TODO(linxGnu): worker pool for this task
-	go func() {
-		reqCtx, cancel := context.WithTimeout(ctx, timeout+time.Second) // wait more than server
+	// create new request context with timeout
+	reqCtx, cancel := context.WithTimeout(ctx, timeout+time.Second) // wait more than server
+	defer cancel()
 
-		commitWithEntry := new(commitWithEntry)
-		res, err := ws.client.do(reqCtx, req, commitWithEntry)
-		if err != nil {
-			if err == context.DeadlineExceeded {
-				watchResult <- &WatchResult{Res: res, Err: fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())}
-			} else {
-				watchResult <- &WatchResult{Res: res, Err: err}
-			}
-		} else {
-			watchResult <- &WatchResult{Commit: commitWithEntry.Commit, Entry: commitWithEntry.Entry,
-				Res: res, Err: nil}
+	// do request
+	commitWithEntry := new(commitWithEntry)
+	res, err := ws.client.do(reqCtx, req, commitWithEntry)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			err = fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())
 		}
+		return &WatchResult{Res: res, Err: err}
+	}
 
-		cancel()
-	}()
+	return &WatchResult{
+		Commit: commitWithEntry.Commit,
+		Entry:  commitWithEntry.Entry,
+		Res:    res,
+	}
 }
 
-const watchTimeout = 1 * time.Minute
+const defaultWatchTimeout = 1 * time.Minute
 
 // These constants represent the state of a watcher.
 const (
@@ -140,24 +141,23 @@ const (
 )
 
 // WatchListener listens to Watcher.
-type WatchListener func(revision int, value interface{})
+type WatchListener func(v WatchResult)
 
 // Watcher watches the changes of a repository or a file.
 type Watcher struct {
 	state int32
 
-	initialValueCh      chan *Latest // channel whose buffer is 1.
-	isInitialValueChSet int32        // 0 is false, 1 is true
+	initialValueCh      chan *WatchResult // channel whose buffer is 1.
+	isInitialValueChSet int32             // 0 is false, 1 is true
 
 	watchCTX        context.Context
 	watchCancelFunc func()
 
 	latest              atomic.Value
-	updateListenerChans []chan *Latest
+	updateListenerChans []chan *WatchResult
 	listenersMutex      sync.RWMutex
 
-	doWatchFunc          func(lastKnownRevision int) <-chan *WatchResult
-	convertingResultFunc func(result *WatchResult) *Latest
+	doWatchFunc func(ctx context.Context, lastKnownRevision int) *WatchResult
 
 	projectName string
 	repoName    string
@@ -166,18 +166,11 @@ type Watcher struct {
 	numAttemptsSoFar int
 }
 
-// Latest represents a holder of the latest known value and its Revision retrieved by Watcher.
-type Latest struct {
-	Revision int
-	Value    interface{}
-	Err      error
-}
-
-func newWatcher(projectName, repoName, pathPattern string) *Watcher {
-	watchCTX, watchCancelFunc := context.WithCancel(context.Background())
+func newWatcher(ctx context.Context, projectName, repoName, pathPattern string) *Watcher {
+	watchCTX, watchCancelFunc := context.WithCancel(ctx)
 	return &Watcher{
 		state:           initial,
-		initialValueCh:  make(chan *Latest, 1),
+		initialValueCh:  make(chan *WatchResult, 1),
 		watchCTX:        watchCTX,
 		watchCancelFunc: watchCancelFunc,
 		projectName:     projectName,
@@ -187,65 +180,46 @@ func newWatcher(projectName, repoName, pathPattern string) *Watcher {
 }
 
 // AwaitInitialValue awaits for the initial value to be available.
-func (w *Watcher) AwaitInitialValue() Latest {
+func (w *Watcher) AwaitInitialValue() *WatchResult {
 	latest := <-w.initialValueCh
 	// Put it back to the channel so that this can return the value multiple times.
 	w.initialValueCh <- latest
-	return *latest
+	return latest
 }
 
 // AwaitInitialValueWith awaits for the initial value to be available during the specified timeout.
-func (w *Watcher) AwaitInitialValueWith(timeout time.Duration) Latest {
+func (w *Watcher) AwaitInitialValueWith(timeout time.Duration) *WatchResult {
 	select {
 	case latest := <-w.initialValueCh:
 		// Put it back to the channel so that this can return the value multiple times.
 		w.initialValueCh <- latest
-		return *latest
+		return latest
 	case <-time.After(timeout):
-		return Latest{Err: fmt.Errorf("failed to get the initial value. timeout: %v", timeout)}
+		return &WatchResult{Err: fmt.Errorf("failed to get the initial value. timeout: %v", timeout)}
 	}
 }
 
-func (w *Watcher) getLatest() (lt *Latest) {
+func (w *Watcher) getLatest() (lt *WatchResult) {
 	loaded := w.latest.Load()
 	if loaded != nil {
-		lt, _ = loaded.(*Latest)
+		lt, _ = loaded.(*WatchResult)
 	}
 	return
 }
 
 // Latest returns the latest Revision and value of WatchFile() or WatchRepository() result.
-func (w *Watcher) Latest() Latest {
+func (w *Watcher) Latest() *WatchResult {
 	latest := w.getLatest()
 	if latest != nil {
-		return *latest
+		return latest
 	}
-	return Latest{Err: ErrLatestNotSet}
-}
-
-// LatestValue returns the latest value of watchFile() or WatchRepository() result.
-func (w *Watcher) LatestValue() (interface{}, error) {
-	latest := w.getLatest()
-	if latest != nil {
-		return latest.Value, latest.Err
-	}
-	return nil, ErrLatestNotSet
-}
-
-// LatestValueOr returns the latest value of watchFile() or WatchRepository() result. If it's not available, this
-// returns the defaultValue.
-func (w *Watcher) LatestValueOr(defaultValue interface{}) interface{} {
-	latest := w.Latest()
-	if latest.Err != nil {
-		return defaultValue
-	}
-	return latest.Value
+	return &WatchResult{Err: ErrLatestNotSet}
 }
 
 // Close stops watching the file specified in the Query or the pathPattern in the repository.
 func (w *Watcher) Close() {
 	atomic.StoreInt32(&w.state, stopped)
-	latest := &Latest{Err: ErrWatcherClosed}
+	latest := &WatchResult{Err: ErrWatcherClosed}
 	if atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
 		// The initial latest was not set before. So write the value to initialValueCh as well.
 		w.initialValueCh <- latest
@@ -265,7 +239,7 @@ func (w *Watcher) Watch(listener WatchListener) error {
 	}
 
 	// start notifier which notify on update
-	ch := make(chan *Latest, 32)
+	ch := make(chan *WatchResult, 32)
 	go w.notifier(listener, ch)
 
 	w.listenersMutex.Lock()
@@ -277,39 +251,39 @@ func (w *Watcher) Watch(listener WatchListener) error {
 		case <-w.watchCTX.Done():
 			return w.watchCTX.Err()
 
-		case ch <- &latest:
+		case ch <- latest:
 		}
 	}
 
 	return nil
 }
 
-func (ws *watchService) fileWatcher(projectName, repoName string, query *Query) (*Watcher, error) {
+func (ws *watchService) fileWatcher(ctx context.Context, projectName, repoName string, query *Query) (*Watcher, error) {
+	return ws.fileWatcherWithTimeout(ctx, projectName, repoName, query, defaultWatchTimeout)
+}
+
+func (ws *watchService) fileWatcherWithTimeout(ctx context.Context, projectName, repoName string, query *Query, timeout time.Duration) (*Watcher, error) {
 	if query == nil {
 		return nil, ErrQueryMustBeSet
 	}
 
-	w := newWatcher(projectName, repoName, query.Path)
-	w.doWatchFunc = func(lastKnownRevision int) <-chan *WatchResult {
-		return ws.watchFile(w.watchCTX, projectName, repoName, strconv.Itoa(lastKnownRevision),
-			query, watchTimeout)
-	}
-	w.convertingResultFunc = func(result *WatchResult) *Latest {
-		value := result.Entry.Content
-		return &Latest{Revision: result.Commit.Revision, Value: value}
+	w := newWatcher(ctx, projectName, repoName, query.Path)
+	w.doWatchFunc = func(ctx context.Context, lastKnownRevision int) *WatchResult {
+		return ws.watchFile(ctx, projectName, repoName, strconv.Itoa(lastKnownRevision),
+			query, timeout)
 	}
 	return w, nil
 }
 
-func (ws *watchService) repoWatcher(projectName, repoName, pathPattern string) (*Watcher, error) {
-	w := newWatcher(projectName, repoName, pathPattern)
-	w.doWatchFunc = func(lastKnownRevision int) <-chan *WatchResult {
-		return ws.watchRepo(w.watchCTX, projectName, repoName, strconv.Itoa(lastKnownRevision),
-			pathPattern, watchTimeout)
-	}
-	w.convertingResultFunc = func(result *WatchResult) *Latest {
-		revision := result.Commit.Revision
-		return &Latest{Revision: revision, Value: revision}
+func (ws *watchService) repoWatcher(ctx context.Context, projectName, repoName, pathPattern string) (*Watcher, error) {
+	return ws.repoWatcherWithTimeout(ctx, projectName, repoName, pathPattern, defaultWatchTimeout)
+}
+
+func (ws *watchService) repoWatcherWithTimeout(ctx context.Context, projectName, repoName, pathPattern string, timeout time.Duration) (*Watcher, error) {
+	w := newWatcher(ctx, projectName, repoName, pathPattern)
+	w.doWatchFunc = func(ctx context.Context, lastKnownRevision int) *WatchResult {
+		return ws.watchRepo(ctx, projectName, repoName, strconv.Itoa(lastKnownRevision),
+			pathPattern, timeout)
 	}
 	return w, nil
 }
@@ -348,52 +322,53 @@ func (w *Watcher) doWatch() {
 
 	var lastKnownRevision int
 	curLatest := w.getLatest()
-	if curLatest == nil || curLatest.Revision == 0 {
-		lastKnownRevision = 1 // Init revision
+	if curLatest == nil || curLatest.Commit.Revision == 0 {
+		lastKnownRevision = -1 // Init revision
 	} else {
-		lastKnownRevision = curLatest.Revision
+		lastKnownRevision = curLatest.Commit.Revision
 	}
 
-	select {
-
-	case <-w.watchCTX.Done():
+	// do watch with context
+	watchResult := w.doWatchFunc(w.watchCTX, lastKnownRevision)
+	if watchResult == nil {
+		// wait for next attempt
+		w.numAttemptsSoFar++
+		w.delay()
 		return
-
-	case watchResult := <-w.doWatchFunc(lastKnownRevision):
-		if watchResult.Err != nil {
-			if watchResult.Err == context.Canceled {
-				// Cancelled by close()
-				return
-			}
-
-			log.Debug(watchResult.Err)
-
-			// wait for next attempt
-			w.numAttemptsSoFar++
-			w.delay()
+	}
+	if watchResult.Err != nil {
+		if watchResult.Err == context.Canceled {
+			// Cancelled by close()
 			return
 		}
 
-		newLatest := w.convertingResultFunc(watchResult)
-		if w.isInitialValueChSet == 0 && atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
-			// The initial latest is set for the first time. So write the value to initialValueCh as well.
-			w.initialValueCh <- newLatest
-		}
-
-		// store latest
-		w.latest.Store(newLatest)
-
-		// log latest revision
-		log.Debugf("Watcher noticed updated file: %s/%s%s, rev=%v",
-			w.projectName, w.repoName, w.pathPattern, newLatest.Revision)
-
-		// notify listener
-		w.notifyListeners()
+		log.Debug(watchResult.Err)
 
 		// wait for next attempt
-		w.numAttemptsSoFar = 0
+		w.numAttemptsSoFar++
 		w.delay()
+		return
 	}
+
+	// converting watch result and feed back to initial value channel if needed
+	if w.isInitialValueChSet == 0 && atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
+		// The initial latest is set for the first time. So write the value to initialValueCh as well.
+		w.initialValueCh <- watchResult
+	}
+
+	// store latest
+	w.latest.Store(watchResult)
+
+	// log latest revision
+	log.Debugf("Watcher noticed updated file: %s/%s%s, rev=%v",
+		w.projectName, w.repoName, w.pathPattern, watchResult.Commit.Revision)
+
+	// notify listener
+	w.notifyListeners()
+
+	// wait for next attempt
+	w.numAttemptsSoFar = 0
+	w.delay()
 }
 
 func (w *Watcher) delay() {
@@ -422,7 +397,7 @@ func (w *Watcher) notifyListeners() {
 	latest := w.Latest()
 
 	w.listenersMutex.RLock()
-	listenerChanSnapshot := make([]chan *Latest, len(w.updateListenerChans))
+	listenerChanSnapshot := make([]chan *WatchResult, len(w.updateListenerChans))
 	copy(listenerChanSnapshot, w.updateListenerChans)
 	w.listenersMutex.RUnlock()
 
@@ -431,12 +406,12 @@ func (w *Watcher) notifyListeners() {
 		case <-w.watchCTX.Done():
 			return
 
-		case listener <- &latest:
+		case listener <- latest:
 		}
 	}
 }
 
-func (w *Watcher) notifier(listener WatchListener, ch <-chan *Latest) {
+func (w *Watcher) notifier(listener WatchListener, ch <-chan *WatchResult) {
 	for {
 		select {
 		case <-w.watchCTX.Done():
@@ -448,7 +423,7 @@ func (w *Watcher) notifier(listener WatchListener, ch <-chan *Latest) {
 			}
 
 			if latest != nil {
-				listener(latest.Revision, latest.Value)
+				listener(*latest)
 			}
 		}
 	}

--- a/watch_service_test.go
+++ b/watch_service_test.go
@@ -38,7 +38,7 @@ func TestWatchFile(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			testHeader(t, r, "if-none-match", "-1")
+			testHeader(t, r, "if-none-match", "1")
 			testHeader(t, r, "prefer", "wait=1")
 
 			// Let's pretend that the content is modified after 100 Millisecond.
@@ -73,7 +73,7 @@ func TestWatchFileInvalidPath(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
-			testHeader(t, r, "if-none-match", "-1")
+			testHeader(t, r, "if-none-match", "1")
 			testHeader(t, r, "prefer", "wait=1")
 
 			// Let's pretend that the content is modified after 100 Millisecond.
@@ -108,11 +108,7 @@ func TestWatcher(t *testing.T) {
 	expectedLastKnownRevision := 1
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		if expectedLastKnownRevision == 1 { // first revision
-			testHeader(t, r, "if-none-match", "-1")
-		} else {
-			testHeader(t, r, "if-none-match", strconv.Itoa(expectedLastKnownRevision))
-		}
+		testHeader(t, r, "if-none-match", strconv.Itoa(expectedLastKnownRevision))
 		testHeader(t, r, "prefer", "wait=60") // watchTimeout is 60 seconds
 
 		// Let's pretend that the content is modified after 100 millisecond and the revision is increased by 1.


### PR DESCRIPTION
- Propose a new Entry model. Entry's content is now []byte and let user manual handle it. This gives flexibility to return various content type.
- A new WatchFile, WatchRepository for Client. Now watching will not happen only one time like before. Changes are notified via channel.
- Types are now immutable to outsider.