### PR TITLE
Change to return the HTTP status code instead of http.Response

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -14,4 +14,6 @@ var (
 
 const (
 	DefaultChannelBuffer = 128
+
+	UnknownHttpStatusCode = 0
 )

--- a/dogma.go
+++ b/dogma.go
@@ -250,63 +250,63 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 }
 
 // CreateProject creates a project.
-func (c *Client) CreateProject(ctx context.Context, name string) (*Project, *http.Response, error) {
+func (c *Client) CreateProject(ctx context.Context, name string) (pro *Project, statusCode int, err error) {
 	return c.project.create(ctx, name)
 }
 
 // RemoveProject removes a project. A removed project can be unremoved using UnremoveProject.
-func (c *Client) RemoveProject(ctx context.Context, name string) (*http.Response, error) {
+func (c *Client) RemoveProject(ctx context.Context, name string) (statusCode int, err error) {
 	return c.project.remove(ctx, name)
 }
 
 // UnremoveProject unremoves a removed project.
-func (c *Client) UnremoveProject(ctx context.Context, name string) (*Project, *http.Response, error) {
+func (c *Client) UnremoveProject(ctx context.Context, name string) (pro *Project, statusCode int, err error) {
 	return c.project.unremove(ctx, name)
 }
 
 // ListProjects returns the list of projects.
-func (c *Client) ListProjects(ctx context.Context) ([]*Project, *http.Response, error) {
+func (c *Client) ListProjects(ctx context.Context) (pros []*Project, statusCode int, err error) {
 	return c.project.list(ctx)
 }
 
 // ListRemovedProjects returns the list of removed projects.
-func (c *Client) ListRemovedProjects(ctx context.Context) ([]*Project, *http.Response, error) {
+func (c *Client) ListRemovedProjects(ctx context.Context) (removedPros []*Project, statusCode int, err error) {
 	return c.project.listRemoved(ctx)
 }
 
 // CreateRepository creates a repository.
 func (c *Client) CreateRepository(
-	ctx context.Context, projectName, repoName string) (*Repository, *http.Response, error) {
+	ctx context.Context, projectName, repoName string) (repo *Repository, statusCode int, err error) {
 	return c.repository.create(ctx, projectName, repoName)
 }
 
 // RemoveRepository removes a repository. A removed repository can be unremoved using UnremoveRepository.
-func (c *Client) RemoveRepository(ctx context.Context, projectName, repoName string) (*http.Response, error) {
+func (c *Client) RemoveRepository(ctx context.Context, projectName, repoName string) (statusCode int, err error) {
 	return c.repository.remove(ctx, projectName, repoName)
 }
 
 // UnremoveRepository unremoves a repository.
 func (c *Client) UnremoveRepository(
-	ctx context.Context, projectName, repoName string) (*Repository, *http.Response, error) {
+	ctx context.Context, projectName, repoName string) (repo *Repository, statusCode int, err error) {
 	return c.repository.unremove(ctx, projectName, repoName)
 }
 
 // ListRepositories returns the list of repositories.
 func (c *Client) ListRepositories(
-	ctx context.Context, projectName string) ([]*Repository, *http.Response, error) {
+	ctx context.Context, projectName string) (repos []*Repository, statusCode int, err error) {
 	return c.repository.list(ctx, projectName)
 }
 
 // ListRemovedRepositories returns the list of the removed repositories which can be unremoved using
 // UnremoveRepository.
 func (c *Client) ListRemovedRepositories(
-	ctx context.Context, projectName string) ([]*Repository, *http.Response, error) {
+	ctx context.Context, projectName string) (removedRepos []*Repository, statusCode int, err error) {
 	return c.repository.listRemoved(ctx, projectName)
 }
 
 // NormalizeRevision converts the relative revision number to the absolute revision number(e.g. -1 -> 3).
 func (c *Client) NormalizeRevision(
-	ctx context.Context, projectName, repoName, revision string) (int, *http.Response, error) {
+	ctx context.Context, projectName, repoName, revision string) (normalizedRev int, statusCode int, err error) {
 	return c.repository.normalizeRevision(ctx, projectName, repoName, revision)
 }
 
@@ -319,13 +319,14 @@ func (c *Client) NormalizeRevision(
 //     - "*.json,/bar/*.txt": use comma to match any patterns
 //
 func (c *Client) ListFiles(ctx context.Context,
-	projectName, repoName, revision, pathPattern string) ([]*Entry, *http.Response, error) {
+	projectName, repoName, revision, pathPattern string) (entries []*Entry, statusCode int, err error) {
 	return c.content.listFiles(ctx, projectName, repoName, revision, pathPattern)
 }
 
 // GetFile returns the file at the specified revision and path with the specified Query.
 func (c *Client) GetFile(
-	ctx context.Context, projectName, repoName, revision string, query *Query) (*Entry, *http.Response, error) {
+	ctx context.Context, projectName, repoName, revision string, query *Query) (entry *Entry,
+	statusCode int, err error) {
 	return c.content.getFile(ctx, projectName, repoName, revision, query)
 }
 
@@ -338,7 +339,7 @@ func (c *Client) GetFile(
 //     - "*.json,/bar/*.txt": use comma to match any patterns
 //
 func (c *Client) GetFiles(ctx context.Context,
-	projectName, repoName, revision, pathPattern string) ([]*Entry, *http.Response, error) {
+	projectName, repoName, revision, pathPattern string) (entries []*Entry, statusCode int, err error) {
 	return c.content.getFiles(ctx, projectName, repoName, revision, pathPattern)
 }
 
@@ -353,14 +354,15 @@ func (c *Client) GetFiles(ctx context.Context,
 //
 // If the from and to are not specified, this will return the history from the init to the latest revision.
 func (c *Client) GetHistory(ctx context.Context,
-	projectName, repoName, from, to, pathPattern string, maxCommits int) ([]*Commit, *http.Response, error) {
+	projectName, repoName, from, to, pathPattern string, maxCommits int) (commits []*Commit,
+	statusCode int, err error) {
 	return c.content.getHistory(ctx, projectName, repoName, from, to, pathPattern, maxCommits)
 }
 
 // GetDiff returns the diff of a file between two revisions. If the from and to are not specified, this will
 // return the diff from the init to the latest revision.
 func (c *Client) GetDiff(ctx context.Context,
-	projectName, repoName, from, to string, query *Query) (*Change, *http.Response, error) {
+	projectName, repoName, from, to string, query *Query) (change *Change, statusCode int, err error) {
 	return c.content.getDiff(ctx, projectName, repoName, from, to, query)
 }
 
@@ -375,13 +377,13 @@ func (c *Client) GetDiff(ctx context.Context,
 //
 // If the from and to are not specified, this will return the diffs from the init to the latest revision.
 func (c *Client) GetDiffs(ctx context.Context,
-	projectName, repoName, from, to, pathPattern string) ([]*Change, *http.Response, error) {
+	projectName, repoName, from, to, pathPattern string) (changes []*Change, statusCode int, err error) {
 	return c.content.getDiffs(ctx, projectName, repoName, from, to, pathPattern)
 }
 
 // Push pushes the specified changes to the repository.
 func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision string,
-	commitMessage *CommitMessage, changes []*Change) (*PushResult, *http.Response, error) {
+	commitMessage *CommitMessage, changes []*Change) (result *PushResult, statusCode int, err error) {
 	return c.content.push(ctx, projectName, repoName, baseRevision, commitMessage, changes)
 }
 

--- a/dogma.go
+++ b/dogma.go
@@ -250,63 +250,63 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 }
 
 // CreateProject creates a project.
-func (c *Client) CreateProject(ctx context.Context, name string) (pro *Project, statusCode int, err error) {
+func (c *Client) CreateProject(ctx context.Context, name string) (pro *Project, httpStatusCode int, err error) {
 	return c.project.create(ctx, name)
 }
 
 // RemoveProject removes a project. A removed project can be unremoved using UnremoveProject.
-func (c *Client) RemoveProject(ctx context.Context, name string) (statusCode int, err error) {
+func (c *Client) RemoveProject(ctx context.Context, name string) (httpStatusCode int, err error) {
 	return c.project.remove(ctx, name)
 }
 
 // UnremoveProject unremoves a removed project.
-func (c *Client) UnremoveProject(ctx context.Context, name string) (pro *Project, statusCode int, err error) {
+func (c *Client) UnremoveProject(ctx context.Context, name string) (pro *Project, httpStatusCode int, err error) {
 	return c.project.unremove(ctx, name)
 }
 
 // ListProjects returns the list of projects.
-func (c *Client) ListProjects(ctx context.Context) (pros []*Project, statusCode int, err error) {
+func (c *Client) ListProjects(ctx context.Context) (pros []*Project, httpStatusCode int, err error) {
 	return c.project.list(ctx)
 }
 
 // ListRemovedProjects returns the list of removed projects.
-func (c *Client) ListRemovedProjects(ctx context.Context) (removedPros []*Project, statusCode int, err error) {
+func (c *Client) ListRemovedProjects(ctx context.Context) (removedPros []*Project, httpStatusCode int, err error) {
 	return c.project.listRemoved(ctx)
 }
 
 // CreateRepository creates a repository.
 func (c *Client) CreateRepository(
-	ctx context.Context, projectName, repoName string) (repo *Repository, statusCode int, err error) {
+	ctx context.Context, projectName, repoName string) (repo *Repository, httpStatusCode int, err error) {
 	return c.repository.create(ctx, projectName, repoName)
 }
 
 // RemoveRepository removes a repository. A removed repository can be unremoved using UnremoveRepository.
-func (c *Client) RemoveRepository(ctx context.Context, projectName, repoName string) (statusCode int, err error) {
+func (c *Client) RemoveRepository(ctx context.Context, projectName, repoName string) (httpStatusCode int, err error) {
 	return c.repository.remove(ctx, projectName, repoName)
 }
 
 // UnremoveRepository unremoves a repository.
 func (c *Client) UnremoveRepository(
-	ctx context.Context, projectName, repoName string) (repo *Repository, statusCode int, err error) {
+	ctx context.Context, projectName, repoName string) (repo *Repository, httpStatusCode int, err error) {
 	return c.repository.unremove(ctx, projectName, repoName)
 }
 
 // ListRepositories returns the list of repositories.
 func (c *Client) ListRepositories(
-	ctx context.Context, projectName string) (repos []*Repository, statusCode int, err error) {
+	ctx context.Context, projectName string) (repos []*Repository, httpStatusCode int, err error) {
 	return c.repository.list(ctx, projectName)
 }
 
 // ListRemovedRepositories returns the list of the removed repositories which can be unremoved using
 // UnremoveRepository.
 func (c *Client) ListRemovedRepositories(
-	ctx context.Context, projectName string) (removedRepos []*Repository, statusCode int, err error) {
+	ctx context.Context, projectName string) (removedRepos []*Repository, httpStatusCode int, err error) {
 	return c.repository.listRemoved(ctx, projectName)
 }
 
 // NormalizeRevision converts the relative revision number to the absolute revision number(e.g. -1 -> 3).
 func (c *Client) NormalizeRevision(
-	ctx context.Context, projectName, repoName, revision string) (normalizedRev int, statusCode int, err error) {
+	ctx context.Context, projectName, repoName, revision string) (normalizedRev int, httpStatusCode int, err error) {
 	return c.repository.normalizeRevision(ctx, projectName, repoName, revision)
 }
 
@@ -319,14 +319,14 @@ func (c *Client) NormalizeRevision(
 //     - "*.json,/bar/*.txt": use comma to match any patterns
 //
 func (c *Client) ListFiles(ctx context.Context,
-	projectName, repoName, revision, pathPattern string) (entries []*Entry, statusCode int, err error) {
+	projectName, repoName, revision, pathPattern string) (entries []*Entry, httpStatusCode int, err error) {
 	return c.content.listFiles(ctx, projectName, repoName, revision, pathPattern)
 }
 
 // GetFile returns the file at the specified revision and path with the specified Query.
 func (c *Client) GetFile(
 	ctx context.Context, projectName, repoName, revision string, query *Query) (entry *Entry,
-	statusCode int, err error) {
+	httpStatusCode int, err error) {
 	return c.content.getFile(ctx, projectName, repoName, revision, query)
 }
 
@@ -339,7 +339,7 @@ func (c *Client) GetFile(
 //     - "*.json,/bar/*.txt": use comma to match any patterns
 //
 func (c *Client) GetFiles(ctx context.Context,
-	projectName, repoName, revision, pathPattern string) (entries []*Entry, statusCode int, err error) {
+	projectName, repoName, revision, pathPattern string) (entries []*Entry, httpStatusCode int, err error) {
 	return c.content.getFiles(ctx, projectName, repoName, revision, pathPattern)
 }
 
@@ -355,14 +355,14 @@ func (c *Client) GetFiles(ctx context.Context,
 // If the from and to are not specified, this will return the history from the init to the latest revision.
 func (c *Client) GetHistory(ctx context.Context,
 	projectName, repoName, from, to, pathPattern string, maxCommits int) (commits []*Commit,
-	statusCode int, err error) {
+	httpStatusCode int, err error) {
 	return c.content.getHistory(ctx, projectName, repoName, from, to, pathPattern, maxCommits)
 }
 
 // GetDiff returns the diff of a file between two revisions. If the from and to are not specified, this will
 // return the diff from the init to the latest revision.
 func (c *Client) GetDiff(ctx context.Context,
-	projectName, repoName, from, to string, query *Query) (change *Change, statusCode int, err error) {
+	projectName, repoName, from, to string, query *Query) (change *Change, httpStatusCode int, err error) {
 	return c.content.getDiff(ctx, projectName, repoName, from, to, query)
 }
 
@@ -377,13 +377,13 @@ func (c *Client) GetDiff(ctx context.Context,
 //
 // If the from and to are not specified, this will return the diffs from the init to the latest revision.
 func (c *Client) GetDiffs(ctx context.Context,
-	projectName, repoName, from, to, pathPattern string) (changes []*Change, statusCode int, err error) {
+	projectName, repoName, from, to, pathPattern string) (changes []*Change, httpStatusCode int, err error) {
 	return c.content.getDiffs(ctx, projectName, repoName, from, to, pathPattern)
 }
 
 // Push pushes the specified changes to the repository.
 func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision string,
-	commitMessage *CommitMessage, changes []*Change) (result *PushResult, statusCode int, err error) {
+	commitMessage *CommitMessage, changes []*Change) (result *PushResult, httpStatusCode int, err error) {
 	return c.content.push(ctx, projectName, repoName, baseRevision, commitMessage, changes)
 }
 

--- a/dogma_test.go
+++ b/dogma_test.go
@@ -62,8 +62,8 @@ func testBody(t *testing.T, req *http.Request, want string) {
 	}
 }
 
-func testStatusCode(t *testing.T, statusCode int, want int) {
-	if got := statusCode; got != want {
+func testStatusCode(t *testing.T, httpStatusCode int, want int) {
+	if got := httpStatusCode; got != want {
 		t.Errorf("Response status: %v, want %v", got, want)
 	}
 }

--- a/dogma_test.go
+++ b/dogma_test.go
@@ -62,8 +62,8 @@ func testBody(t *testing.T, req *http.Request, want string) {
 	}
 }
 
-func testStatus(t *testing.T, res *http.Response, want int) {
-	if got := res.StatusCode; got != want {
+func testStatusCode(t *testing.T, statusCode int, want int) {
+	if got := statusCode; got != want {
 		t.Errorf("Response status: %v, want %v", got, want)
 	}
 }
@@ -100,7 +100,7 @@ func TestNewClient(t *testing.T) {
 	req, _ := c.newRequest(http.MethodGet, "/test", nil)
 
 	res, _ := c.do(context.Background(), req, nil)
-	testStatus(t, res, 200)
+	testStatusCode(t, res.StatusCode, 200)
 }
 
 func TestNewClientWithHTTPClient(t *testing.T) {

--- a/project_service.go
+++ b/project_service.go
@@ -34,82 +34,82 @@ type Author struct {
 	Email string `json:"email,omitempty"`
 }
 
-func (p *projectService) create(ctx context.Context, name string) (*Project, *http.Response, error) {
+func (p *projectService) create(ctx context.Context, name string) (*Project, int, error) {
 	u := defaultPathPrefix + "projects"
 
 	req, err := p.client.newRequest(http.MethodPost, u, &Project{Name: name})
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	project := new(Project)
 	res, err := p.client.do(ctx, req, project)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return project, res, nil
+	return project, res.StatusCode, nil
 }
 
-func (p *projectService) remove(ctx context.Context, name string) (*http.Response, error) {
+func (p *projectService) remove(ctx context.Context, name string) (int, error) {
 	u := defaultPathPrefix + "projects/" + name
 
 	req, err := p.client.newRequest(http.MethodDelete, u, nil)
 	if err != nil {
-		return nil, err
+		return UnknownHttpStatusCode, err
 	}
 
 	res, err := p.client.do(ctx, req, nil)
 	if err != nil {
-		return res, err
+		return res.StatusCode, err
 	}
-	return res, nil
+	return res.StatusCode, nil
 }
 
-func (p *projectService) unremove(ctx context.Context, name string) (*Project, *http.Response, error) {
+func (p *projectService) unremove(ctx context.Context, name string) (*Project, int, error) {
 	u := defaultPathPrefix + "projects/" + name
 
 	req, err := p.client.newRequest(http.MethodPatch, u, `[{"op":"replace", "path":"/status", "value":"active"}]`)
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	project := new(Project)
 	res, err := p.client.do(ctx, req, project)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return project, res, nil
+	return project, res.StatusCode, nil
 }
 
-func (p *projectService) list(ctx context.Context) ([]*Project, *http.Response, error) {
+func (p *projectService) list(ctx context.Context) ([]*Project, int, error) {
 	u := defaultPathPrefix + "projects"
 
 	req, err := p.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	var projects []*Project
 	res, err := p.client.do(ctx, req, &projects)
 
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return projects, res, nil
+	return projects, res.StatusCode, nil
 }
 
-func (p *projectService) listRemoved(ctx context.Context) ([]*Project, *http.Response, error) {
+func (p *projectService) listRemoved(ctx context.Context) ([]*Project, int, error) {
 	u := defaultPathPrefix + "projects?status=removed"
 
 	req, err := p.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	var projects []*Project
 	res, err := p.client.do(ctx, req, &projects)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return projects, res, nil
+	return projects, res.StatusCode, nil
 }

--- a/project_service_test.go
+++ b/project_service_test.go
@@ -43,8 +43,8 @@ func TestCreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"name":"foo", "creator":{"name":"minux", "email":"minux@m.x"}}`)
 	})
 
-	project, statusCode, _ := c.CreateProject(context.Background(), input.Name)
-	testStatusCode(t, statusCode, 201)
+	project, httpStatusCode, _ := c.CreateProject(context.Background(), input.Name)
+	testStatusCode(t, httpStatusCode, 201)
 
 	want := &Project{Name: "foo", Creator: Author{Name: "minux", Email: "minux@m.x"}}
 	if !reflect.DeepEqual(project, want) {
@@ -61,8 +61,8 @@ func TestRemoveProject(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	statusCode, _ := c.RemoveProject(context.Background(), "foo")
-	testStatusCode(t, statusCode, 204)
+	httpStatusCode, _ := c.RemoveProject(context.Background(), "foo")
+	testStatusCode(t, httpStatusCode, 204)
 }
 
 func TestUnremoveProject(t *testing.T) {

--- a/project_service_test.go
+++ b/project_service_test.go
@@ -43,8 +43,8 @@ func TestCreateProject(t *testing.T) {
 		fmt.Fprint(w, `{"name":"foo", "creator":{"name":"minux", "email":"minux@m.x"}}`)
 	})
 
-	project, res, _ := c.CreateProject(context.Background(), input.Name)
-	testStatus(t, res, 201)
+	project, statusCode, _ := c.CreateProject(context.Background(), input.Name)
+	testStatusCode(t, statusCode, 201)
 
 	want := &Project{Name: "foo", Creator: Author{Name: "minux", Email: "minux@m.x"}}
 	if !reflect.DeepEqual(project, want) {
@@ -61,8 +61,8 @@ func TestRemoveProject(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	res, _ := c.RemoveProject(context.Background(), "foo")
-	testStatus(t, res, 204)
+	statusCode, _ := c.RemoveProject(context.Background(), "foo")
+	testStatusCode(t, statusCode, 204)
 }
 
 func TestUnremoveProject(t *testing.T) {

--- a/repository_service.go
+++ b/repository_service.go
@@ -31,105 +31,101 @@ type Repository struct {
 	CreatedAt    string  `json:"createdAt,omitempty"`
 }
 
-func (r *repositoryService) create(ctx context.Context, projectName, repoName string) (*Repository,
-	*http.Response, error) {
+func (r *repositoryService) create(ctx context.Context, projectName, repoName string) (*Repository, int, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos", defaultPathPrefix, projectName)
 
 	req, err := r.client.newRequest(http.MethodPost, u, &Repository{Name: repoName})
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	repo := new(Repository)
 	res, err := r.client.do(ctx, req, repo)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
 
-	return repo, res, nil
+	return repo, res.StatusCode, nil
 }
 
-func (r *repositoryService) remove(ctx context.Context, projectName, repoName string) (*http.Response, error) {
+func (r *repositoryService) remove(ctx context.Context, projectName, repoName string) (int, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v", defaultPathPrefix, projectName, repoName)
 
 	req, err := r.client.newRequest(http.MethodDelete, u, nil)
 	if err != nil {
-		return nil, err
+		return UnknownHttpStatusCode, err
 	}
 
 	res, err := r.client.do(ctx, req, nil)
 	if err != nil {
-		return res, err
+		return res.StatusCode, err
 	}
-	return res, nil
+	return res.StatusCode, nil
 }
 
-func (r *repositoryService) unremove(ctx context.Context, projectName, repoName string) (*Repository,
-	*http.Response, error) {
+func (r *repositoryService) unremove(ctx context.Context, projectName, repoName string) (*Repository, int, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v", defaultPathPrefix, projectName, repoName)
 
 	req, err := r.client.newRequest(http.MethodPatch, u, `[{"op":"replace", "path":"/status", "value":"active"}]`)
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	repo := new(Repository)
 	res, err := r.client.do(ctx, req, repo)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return repo, res, nil
+	return repo, res.StatusCode, nil
 }
 
-func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Repository,
-	*http.Response, error) {
+func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Repository, int, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos", defaultPathPrefix, projectName)
 
 	req, err := r.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	var repos []*Repository
 	res, err := r.client.do(ctx, req, &repos)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return repos, res, nil
+	return repos, res.StatusCode, nil
 }
 
-func (r *repositoryService) listRemoved(ctx context.Context, projectName string) ([]*Repository,
-	*http.Response, error) {
+func (r *repositoryService) listRemoved(ctx context.Context, projectName string) ([]*Repository, int, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos?status=removed", defaultPathPrefix, projectName)
 
 	req, err := r.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, UnknownHttpStatusCode, err
 	}
 
 	var repos []*Repository
 	res, err := r.client.do(ctx, req, &repos)
 	if err != nil {
-		return nil, res, err
+		return nil, res.StatusCode, err
 	}
-	return repos, res, nil
+	return repos, res.StatusCode, nil
 }
 
 func (r *repositoryService) normalizeRevision(
-	ctx context.Context, projectName, repoName, revision string) (int, *http.Response, error) {
+	ctx context.Context, projectName, repoName, revision string) (int, int, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v/revision/%v", defaultPathPrefix, projectName, repoName, revision)
 
 	req, err := r.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
-		return -1, nil, err
+		return -1, UnknownHttpStatusCode, err
 	}
 
 	rev := new(rev)
 	res, err := r.client.do(ctx, req, rev)
 	if err != nil {
-		return -1, nil, err
+		return -1, res.StatusCode, err
 	}
-	return rev.Rev, res, nil
+	return rev.Rev, res.StatusCode, nil
 }
 
 type rev struct {

--- a/repository_service_test.go
+++ b/repository_service_test.go
@@ -43,8 +43,8 @@ func TestCreateRepository(t *testing.T) {
 		fmt.Fprint(w, `{"name":"bar", "creator":{"name":"minux", "email":"minux@m.x"}, "headRevision": 2}`)
 	})
 
-	repo, statusCode, _ := c.CreateRepository(context.Background(), "foo", "bar")
-	testStatusCode(t, statusCode, 201)
+	repo, httpStatusCode, _ := c.CreateRepository(context.Background(), "foo", "bar")
+	testStatusCode(t, httpStatusCode, 201)
 
 	want := &Repository{Name: "bar", Creator: &Author{Name: "minux", Email: "minux@m.x"}, HeadRevision: 2}
 	if !reflect.DeepEqual(repo, want) {
@@ -61,8 +61,8 @@ func TestRemoveRepository(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	statusCode, _ := c.RemoveRepository(context.Background(), "foo", "bar")
-	testStatusCode(t, statusCode, 204)
+	httpStatusCode, _ := c.RemoveRepository(context.Background(), "foo", "bar")
+	testStatusCode(t, httpStatusCode, 204)
 }
 
 func TestUnremoveRepository(t *testing.T) {

--- a/repository_service_test.go
+++ b/repository_service_test.go
@@ -43,8 +43,8 @@ func TestCreateRepository(t *testing.T) {
 		fmt.Fprint(w, `{"name":"bar", "creator":{"name":"minux", "email":"minux@m.x"}, "headRevision": 2}`)
 	})
 
-	repo, res, _ := c.CreateRepository(context.Background(), "foo", "bar")
-	testStatus(t, res, 201)
+	repo, statusCode, _ := c.CreateRepository(context.Background(), "foo", "bar")
+	testStatusCode(t, statusCode, 201)
 
 	want := &Repository{Name: "bar", Creator: &Author{Name: "minux", Email: "minux@m.x"}, HeadRevision: 2}
 	if !reflect.DeepEqual(repo, want) {
@@ -61,8 +61,8 @@ func TestRemoveRepository(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	res, _ := c.RemoveRepository(context.Background(), "foo", "bar")
-	testStatus(t, res, 204)
+	statusCode, _ := c.RemoveRepository(context.Background(), "foo", "bar")
+	testStatusCode(t, statusCode, 204)
 }
 
 func TestUnremoveRepository(t *testing.T) {

--- a/watch_service.go
+++ b/watch_service.go
@@ -30,10 +30,10 @@ type watchService service
 
 // WatchResult represents a result from watch operation.
 type WatchResult struct {
-	Revision int   `json:"revision"`
-	Entry    Entry `json:"entry,omitempty"`
-	Res      *http.Response
-	Err      error
+	Revision   int   `json:"revision"`
+	Entry      Entry `json:"entry,omitempty"`
+	StatusCode int
+	Err        error
 }
 
 func (ws *watchService) watchFile(
@@ -116,10 +116,10 @@ func (ws *watchService) watchRequest(
 		if err == context.DeadlineExceeded {
 			err = fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())
 		}
-		return &WatchResult{Res: res, Err: err}
+		return &WatchResult{StatusCode: res.StatusCode, Err: err}
 	}
 
-	watchResult.Res = res
+	watchResult.StatusCode = res.StatusCode
 	return watchResult
 }
 

--- a/watch_service.go
+++ b/watch_service.go
@@ -30,10 +30,10 @@ type watchService service
 
 // WatchResult represents a result from watch operation.
 type WatchResult struct {
-	Revision   int   `json:"revision"`
-	Entry      Entry `json:"entry,omitempty"`
-	StatusCode int
-	Err        error
+	Revision       int   `json:"revision"`
+	Entry          Entry `json:"entry,omitempty"`
+	HttpStatusCode int
+	Err            error
 }
 
 func (ws *watchService) watchFile(
@@ -116,10 +116,10 @@ func (ws *watchService) watchRequest(
 		if err == context.DeadlineExceeded {
 			err = fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())
 		}
-		return &WatchResult{StatusCode: res.StatusCode, Err: err}
+		return &WatchResult{HttpStatusCode: res.StatusCode, Err: err}
 	}
 
-	watchResult.StatusCode = res.StatusCode
+	watchResult.HttpStatusCode = res.StatusCode
 	return watchResult
 }
 


### PR DESCRIPTION
Motivation:
We used to return the `http.Response` whose body was closed.
A user cannot read the body and we handle the error cases well, perhaps it will be better to just return the HTTP status code instead of the whole response.

Modifications:
- Change to return the HTTP status code in our APIs

Result:
- Less confusion