### PR TITLE
Fix bug + breaking change: fix response nil

### DIFF
--- a/content_service.go
+++ b/content_service.go
@@ -172,11 +172,11 @@ func (con *contentService) listFiles(ctx context.Context,
 	}
 
 	var entries []*Entry
-	res, err := con.client.do(ctx, req, &entries)
+	statusCode, err := con.client.do(ctx, req, &entries)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return entries, res.StatusCode, nil
+	return entries, statusCode, nil
 }
 
 func encodeValues(v *url.Values) string {
@@ -211,12 +211,12 @@ func (con *contentService) getFile(
 	}
 
 	entry := new(Entry)
-	res, err := con.client.do(ctx, req, entry)
+	statusCode, err := con.client.do(ctx, req, entry)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
 
-	return entry, res.StatusCode, nil
+	return entry, statusCode, nil
 }
 
 // getFileURLValues currently only supports JSON path.
@@ -264,11 +264,11 @@ func (con *contentService) getFiles(ctx context.Context,
 	}
 
 	var entries []*Entry
-	res, err := con.client.do(ctx, req, &entries)
+	statusCode, err := con.client.do(ctx, req, &entries)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return entries, res.StatusCode, nil
+	return entries, statusCode, nil
 }
 
 func (con *contentService) getHistory(ctx context.Context,
@@ -293,11 +293,11 @@ func (con *contentService) getHistory(ctx context.Context,
 	}
 
 	var commits []*Commit
-	res, err := con.client.do(ctx, req, &commits)
+	statusCode, err := con.client.do(ctx, req, &commits)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return commits, res.StatusCode, nil
+	return commits, statusCode, nil
 }
 
 func (con *contentService) getDiff(ctx context.Context,
@@ -331,12 +331,12 @@ func (con *contentService) getDiff(ctx context.Context,
 	}
 
 	change := new(Change)
-	res, err := con.client.do(ctx, req, change)
+	statusCode, err := con.client.do(ctx, req, change)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
 
-	return change, res.StatusCode, nil
+	return change, statusCode, nil
 }
 
 func setFromTo(v *url.Values, from, to string) {
@@ -367,11 +367,11 @@ func (con *contentService) getDiffs(ctx context.Context,
 	}
 
 	var changes []*Change
-	res, err := con.client.do(ctx, req, &changes)
+	statusCode, err := con.client.do(ctx, req, &changes)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return changes, res.StatusCode, nil
+	return changes, statusCode, nil
 }
 
 type push struct {
@@ -404,9 +404,9 @@ func (con *contentService) push(ctx context.Context, projectName, repoName, base
 	}
 
 	pushResult := new(PushResult)
-	res, err := con.client.do(ctx, req, pushResult)
+	statusCode, err := con.client.do(ctx, req, pushResult)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return pushResult, res.StatusCode, nil
+	return pushResult, statusCode, nil
 }

--- a/content_service.go
+++ b/content_service.go
@@ -172,11 +172,11 @@ func (con *contentService) listFiles(ctx context.Context,
 	}
 
 	var entries []*Entry
-	statusCode, err := con.client.do(ctx, req, &entries)
+	httpStatusCode, err := con.client.do(ctx, req, &entries)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return entries, statusCode, nil
+	return entries, httpStatusCode, nil
 }
 
 func encodeValues(v *url.Values) string {
@@ -211,12 +211,12 @@ func (con *contentService) getFile(
 	}
 
 	entry := new(Entry)
-	statusCode, err := con.client.do(ctx, req, entry)
+	httpStatusCode, err := con.client.do(ctx, req, entry)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
 
-	return entry, statusCode, nil
+	return entry, httpStatusCode, nil
 }
 
 // getFileURLValues currently only supports JSON path.
@@ -264,11 +264,11 @@ func (con *contentService) getFiles(ctx context.Context,
 	}
 
 	var entries []*Entry
-	statusCode, err := con.client.do(ctx, req, &entries)
+	httpStatusCode, err := con.client.do(ctx, req, &entries)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return entries, statusCode, nil
+	return entries, httpStatusCode, nil
 }
 
 func (con *contentService) getHistory(ctx context.Context,
@@ -293,11 +293,11 @@ func (con *contentService) getHistory(ctx context.Context,
 	}
 
 	var commits []*Commit
-	statusCode, err := con.client.do(ctx, req, &commits)
+	httpStatusCode, err := con.client.do(ctx, req, &commits)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return commits, statusCode, nil
+	return commits, httpStatusCode, nil
 }
 
 func (con *contentService) getDiff(ctx context.Context,
@@ -331,12 +331,12 @@ func (con *contentService) getDiff(ctx context.Context,
 	}
 
 	change := new(Change)
-	statusCode, err := con.client.do(ctx, req, change)
+	httpStatusCode, err := con.client.do(ctx, req, change)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
 
-	return change, statusCode, nil
+	return change, httpStatusCode, nil
 }
 
 func setFromTo(v *url.Values, from, to string) {
@@ -367,11 +367,11 @@ func (con *contentService) getDiffs(ctx context.Context,
 	}
 
 	var changes []*Change
-	statusCode, err := con.client.do(ctx, req, &changes)
+	httpStatusCode, err := con.client.do(ctx, req, &changes)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return changes, statusCode, nil
+	return changes, httpStatusCode, nil
 }
 
 type push struct {
@@ -404,9 +404,9 @@ func (con *contentService) push(ctx context.Context, projectName, repoName, base
 	}
 
 	pushResult := new(PushResult)
-	statusCode, err := con.client.do(ctx, req, pushResult)
+	httpStatusCode, err := con.client.do(ctx, req, pushResult)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return pushResult, statusCode, nil
+	return pushResult, httpStatusCode, nil
 }

--- a/dogma.go
+++ b/dogma.go
@@ -215,7 +215,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 
 	res, err := c.client.Do(req)
 	if err != nil {
-		return nil, err
+		return &http.Response{StatusCode: -1}, err
 	}
 	defer func() {
 		// drain up 512 bytes and close the body to reuse connection

--- a/dogma.go
+++ b/dogma.go
@@ -210,12 +210,12 @@ type errorMessage struct {
 	Message string `json:"message"`
 }
 
-func (c *Client) do(ctx context.Context, req *http.Request, resContent interface{}) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, req *http.Request, resContent interface{}) (int, error) {
 	req = req.WithContext(ctx)
 
 	res, err := c.client.Do(req)
 	if err != nil {
-		return &http.Response{StatusCode: -1}, err
+		return UnknownHttpStatusCode, err
 	}
 	defer func() {
 		// drain up 512 bytes and close the body to reuse connection
@@ -237,7 +237,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 			err = fmt.Errorf("%s (status: %v)", errorMessage.Message, res.StatusCode)
 		}
 
-		return res, err
+		return res.StatusCode, err
 	}
 
 	if resContent != nil {
@@ -246,7 +246,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 			err = nil
 		}
 	}
-	return res, err
+	return res.StatusCode, err
 }
 
 // CreateProject creates a project.

--- a/dogma_test.go
+++ b/dogma_test.go
@@ -99,8 +99,8 @@ func TestNewClient(t *testing.T) {
 	c, _ := NewClient(server.URL, "foo", "bar")
 	req, _ := c.newRequest(http.MethodGet, "/test", nil)
 
-	statusCode, _ := c.do(context.Background(), req, nil)
-	testStatusCode(t, statusCode, 200)
+	httpStatusCode, _ := c.do(context.Background(), req, nil)
+	testStatusCode(t, httpStatusCode, 200)
 }
 
 func TestNewClientWithHTTPClient(t *testing.T) {

--- a/dogma_test.go
+++ b/dogma_test.go
@@ -99,8 +99,8 @@ func TestNewClient(t *testing.T) {
 	c, _ := NewClient(server.URL, "foo", "bar")
 	req, _ := c.newRequest(http.MethodGet, "/test", nil)
 
-	res, _ := c.do(context.Background(), req, nil)
-	testStatusCode(t, res.StatusCode, 200)
+	statusCode, _ := c.do(context.Background(), req, nil)
+	testStatusCode(t, statusCode, 200)
 }
 
 func TestNewClientWithHTTPClient(t *testing.T) {

--- a/project_service.go
+++ b/project_service.go
@@ -43,11 +43,11 @@ func (p *projectService) create(ctx context.Context, name string) (*Project, int
 	}
 
 	project := new(Project)
-	statusCode, err := p.client.do(ctx, req, project)
+	httpStatusCode, err := p.client.do(ctx, req, project)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return project, statusCode, nil
+	return project, httpStatusCode, nil
 }
 
 func (p *projectService) remove(ctx context.Context, name string) (int, error) {
@@ -58,11 +58,11 @@ func (p *projectService) remove(ctx context.Context, name string) (int, error) {
 		return UnknownHttpStatusCode, err
 	}
 
-	statusCode, err := p.client.do(ctx, req, nil)
+	httpStatusCode, err := p.client.do(ctx, req, nil)
 	if err != nil {
-		return statusCode, err
+		return httpStatusCode, err
 	}
-	return statusCode, nil
+	return httpStatusCode, nil
 }
 
 func (p *projectService) unremove(ctx context.Context, name string) (*Project, int, error) {
@@ -74,11 +74,11 @@ func (p *projectService) unremove(ctx context.Context, name string) (*Project, i
 	}
 
 	project := new(Project)
-	statusCode, err := p.client.do(ctx, req, project)
+	httpStatusCode, err := p.client.do(ctx, req, project)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return project, statusCode, nil
+	return project, httpStatusCode, nil
 }
 
 func (p *projectService) list(ctx context.Context) ([]*Project, int, error) {
@@ -90,11 +90,11 @@ func (p *projectService) list(ctx context.Context) ([]*Project, int, error) {
 	}
 
 	var projects []*Project
-	statusCode, err := p.client.do(ctx, req, &projects)
+	httpStatusCode, err := p.client.do(ctx, req, &projects)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return projects, statusCode, nil
+	return projects, httpStatusCode, nil
 }
 
 func (p *projectService) listRemoved(ctx context.Context) ([]*Project, int, error) {
@@ -106,9 +106,9 @@ func (p *projectService) listRemoved(ctx context.Context) ([]*Project, int, erro
 	}
 
 	var projects []*Project
-	statusCode, err := p.client.do(ctx, req, &projects)
+	httpStatusCode, err := p.client.do(ctx, req, &projects)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return projects, statusCode, nil
+	return projects, httpStatusCode, nil
 }

--- a/project_service.go
+++ b/project_service.go
@@ -43,11 +43,11 @@ func (p *projectService) create(ctx context.Context, name string) (*Project, int
 	}
 
 	project := new(Project)
-	res, err := p.client.do(ctx, req, project)
+	statusCode, err := p.client.do(ctx, req, project)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return project, res.StatusCode, nil
+	return project, statusCode, nil
 }
 
 func (p *projectService) remove(ctx context.Context, name string) (int, error) {
@@ -58,11 +58,11 @@ func (p *projectService) remove(ctx context.Context, name string) (int, error) {
 		return UnknownHttpStatusCode, err
 	}
 
-	res, err := p.client.do(ctx, req, nil)
+	statusCode, err := p.client.do(ctx, req, nil)
 	if err != nil {
-		return res.StatusCode, err
+		return statusCode, err
 	}
-	return res.StatusCode, nil
+	return statusCode, nil
 }
 
 func (p *projectService) unremove(ctx context.Context, name string) (*Project, int, error) {
@@ -74,11 +74,11 @@ func (p *projectService) unremove(ctx context.Context, name string) (*Project, i
 	}
 
 	project := new(Project)
-	res, err := p.client.do(ctx, req, project)
+	statusCode, err := p.client.do(ctx, req, project)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return project, res.StatusCode, nil
+	return project, statusCode, nil
 }
 
 func (p *projectService) list(ctx context.Context) ([]*Project, int, error) {
@@ -90,12 +90,11 @@ func (p *projectService) list(ctx context.Context) ([]*Project, int, error) {
 	}
 
 	var projects []*Project
-	res, err := p.client.do(ctx, req, &projects)
-
+	statusCode, err := p.client.do(ctx, req, &projects)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return projects, res.StatusCode, nil
+	return projects, statusCode, nil
 }
 
 func (p *projectService) listRemoved(ctx context.Context) ([]*Project, int, error) {
@@ -107,9 +106,9 @@ func (p *projectService) listRemoved(ctx context.Context) ([]*Project, int, erro
 	}
 
 	var projects []*Project
-	res, err := p.client.do(ctx, req, &projects)
+	statusCode, err := p.client.do(ctx, req, &projects)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return projects, res.StatusCode, nil
+	return projects, statusCode, nil
 }

--- a/repository_service.go
+++ b/repository_service.go
@@ -40,12 +40,12 @@ func (r *repositoryService) create(ctx context.Context, projectName, repoName st
 	}
 
 	repo := new(Repository)
-	statusCode, err := r.client.do(ctx, req, repo)
+	httpStatusCode, err := r.client.do(ctx, req, repo)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
 
-	return repo, statusCode, nil
+	return repo, httpStatusCode, nil
 }
 
 func (r *repositoryService) remove(ctx context.Context, projectName, repoName string) (int, error) {
@@ -56,11 +56,11 @@ func (r *repositoryService) remove(ctx context.Context, projectName, repoName st
 		return UnknownHttpStatusCode, err
 	}
 
-	statusCode, err := r.client.do(ctx, req, nil)
+	httpStatusCode, err := r.client.do(ctx, req, nil)
 	if err != nil {
-		return statusCode, err
+		return httpStatusCode, err
 	}
-	return statusCode, nil
+	return httpStatusCode, nil
 }
 
 func (r *repositoryService) unremove(ctx context.Context, projectName, repoName string) (*Repository, int, error) {
@@ -72,11 +72,11 @@ func (r *repositoryService) unremove(ctx context.Context, projectName, repoName 
 	}
 
 	repo := new(Repository)
-	statusCode, err := r.client.do(ctx, req, repo)
+	httpStatusCode, err := r.client.do(ctx, req, repo)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return repo, statusCode, nil
+	return repo, httpStatusCode, nil
 }
 
 func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Repository, int, error) {
@@ -88,11 +88,11 @@ func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Re
 	}
 
 	var repos []*Repository
-	statusCode, err := r.client.do(ctx, req, &repos)
+	httpStatusCode, err := r.client.do(ctx, req, &repos)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return repos, statusCode, nil
+	return repos, httpStatusCode, nil
 }
 
 func (r *repositoryService) listRemoved(ctx context.Context, projectName string) ([]*Repository, int, error) {
@@ -104,11 +104,11 @@ func (r *repositoryService) listRemoved(ctx context.Context, projectName string)
 	}
 
 	var repos []*Repository
-	statusCode, err := r.client.do(ctx, req, &repos)
+	httpStatusCode, err := r.client.do(ctx, req, &repos)
 	if err != nil {
-		return nil, statusCode, err
+		return nil, httpStatusCode, err
 	}
-	return repos, statusCode, nil
+	return repos, httpStatusCode, nil
 }
 
 func (r *repositoryService) normalizeRevision(
@@ -121,11 +121,11 @@ func (r *repositoryService) normalizeRevision(
 	}
 
 	rev := new(rev)
-	statusCode, err := r.client.do(ctx, req, rev)
+	httpStatusCode, err := r.client.do(ctx, req, rev)
 	if err != nil {
-		return -1, statusCode, err
+		return -1, httpStatusCode, err
 	}
-	return rev.Rev, statusCode, nil
+	return rev.Rev, httpStatusCode, nil
 }
 
 type rev struct {

--- a/repository_service.go
+++ b/repository_service.go
@@ -40,12 +40,12 @@ func (r *repositoryService) create(ctx context.Context, projectName, repoName st
 	}
 
 	repo := new(Repository)
-	res, err := r.client.do(ctx, req, repo)
+	statusCode, err := r.client.do(ctx, req, repo)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
 
-	return repo, res.StatusCode, nil
+	return repo, statusCode, nil
 }
 
 func (r *repositoryService) remove(ctx context.Context, projectName, repoName string) (int, error) {
@@ -56,11 +56,11 @@ func (r *repositoryService) remove(ctx context.Context, projectName, repoName st
 		return UnknownHttpStatusCode, err
 	}
 
-	res, err := r.client.do(ctx, req, nil)
+	statusCode, err := r.client.do(ctx, req, nil)
 	if err != nil {
-		return res.StatusCode, err
+		return statusCode, err
 	}
-	return res.StatusCode, nil
+	return statusCode, nil
 }
 
 func (r *repositoryService) unremove(ctx context.Context, projectName, repoName string) (*Repository, int, error) {
@@ -72,11 +72,11 @@ func (r *repositoryService) unremove(ctx context.Context, projectName, repoName 
 	}
 
 	repo := new(Repository)
-	res, err := r.client.do(ctx, req, repo)
+	statusCode, err := r.client.do(ctx, req, repo)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return repo, res.StatusCode, nil
+	return repo, statusCode, nil
 }
 
 func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Repository, int, error) {
@@ -88,11 +88,11 @@ func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Re
 	}
 
 	var repos []*Repository
-	res, err := r.client.do(ctx, req, &repos)
+	statusCode, err := r.client.do(ctx, req, &repos)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return repos, res.StatusCode, nil
+	return repos, statusCode, nil
 }
 
 func (r *repositoryService) listRemoved(ctx context.Context, projectName string) ([]*Repository, int, error) {
@@ -104,11 +104,11 @@ func (r *repositoryService) listRemoved(ctx context.Context, projectName string)
 	}
 
 	var repos []*Repository
-	res, err := r.client.do(ctx, req, &repos)
+	statusCode, err := r.client.do(ctx, req, &repos)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, statusCode, err
 	}
-	return repos, res.StatusCode, nil
+	return repos, statusCode, nil
 }
 
 func (r *repositoryService) normalizeRevision(
@@ -121,11 +121,11 @@ func (r *repositoryService) normalizeRevision(
 	}
 
 	rev := new(rev)
-	res, err := r.client.do(ctx, req, rev)
+	statusCode, err := r.client.do(ctx, req, rev)
 	if err != nil {
-		return -1, res.StatusCode, err
+		return -1, statusCode, err
 	}
-	return rev.Rev, res.StatusCode, nil
+	return rev.Rev, statusCode, nil
 }
 
 type rev struct {

--- a/watch_service.go
+++ b/watch_service.go
@@ -111,15 +111,15 @@ func (ws *watchService) watchRequest(
 	defer cancel()
 
 	watchResult := new(WatchResult)
-	statusCode, err := ws.client.do(reqCtx, req, watchResult)
+	httpStatusCode, err := ws.client.do(reqCtx, req, watchResult)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			err = fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())
 		}
-		return &WatchResult{HttpStatusCode: statusCode, Err: err}
+		return &WatchResult{HttpStatusCode: httpStatusCode, Err: err}
 	}
 
-	watchResult.HttpStatusCode = statusCode
+	watchResult.HttpStatusCode = httpStatusCode
 	return watchResult
 }
 

--- a/watch_service.go
+++ b/watch_service.go
@@ -111,15 +111,15 @@ func (ws *watchService) watchRequest(
 	defer cancel()
 
 	watchResult := new(WatchResult)
-	res, err := ws.client.do(reqCtx, req, watchResult)
+	statusCode, err := ws.client.do(reqCtx, req, watchResult)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			err = fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())
 		}
-		return &WatchResult{HttpStatusCode: res.StatusCode, Err: err}
+		return &WatchResult{HttpStatusCode: statusCode, Err: err}
 	}
 
-	watchResult.HttpStatusCode = res.StatusCode
+	watchResult.HttpStatusCode = statusCode
 	return watchResult
 }
 


### PR DESCRIPTION
- When client could not connect to central dogma server in someway (example: central dogma server restart/stop), resp (response) object is `nil`. However we keep using `resp.StatusCode` everywhere.
- This fix also raises breaking change to return status code directly from dogma client.