### PR TITLE
Increase client-side timeout when watching

### DIFF
--- a/watch_service.go
+++ b/watch_service.go
@@ -26,6 +26,8 @@ import (
 	"time"
 )
 
+const timeoutBuffer = 5 * time.Second
+
 type watchService service
 
 // WatchResult represents a result from watch operation.
@@ -107,7 +109,7 @@ func (ws *watchService) watchRequest(
 	}
 
 	// create new request context with timeout
-	reqCtx, cancel := context.WithTimeout(ctx, timeout+time.Second) // wait more than server
+	reqCtx, cancel := context.WithTimeout(ctx, timeout+timeoutBuffer) // wait more than server
 	defer cancel()
 
 	watchResult := new(WatchResult)


### PR DESCRIPTION
Motivation:
`AbortedStreamException` is raised a lot in Central Dogma server. This happens when a client sends a request and closes the connection before it gets a response.
I think it happens in the watch API:
- The `Watcher` sends a watch request.
- It sets the client-side timeout as original timeout + 1 second.
- The original timeout is used in the server-side. The server responses with
`304` HTTP status when it times out.
- However, the client-side timeout is too short, it closes the connection even before it gets a response.

This results in a lot of `AbortedStreamException` in the server.
If we increase the client-side timeout and the client gets the `304` response, it will read the response and reuse the connection so there will be no problem.

Modification:

- Increase the timeout buffer to 5 seconds

Result:

- Fewer exception logs