### PR TITLE
Fix to handle 304 when watching

### DIFF
--- a/content_service.go
+++ b/content_service.go
@@ -172,7 +172,7 @@ func (con *contentService) listFiles(ctx context.Context,
 	}
 
 	var entries []*Entry
-	httpStatusCode, err := con.client.do(ctx, req, &entries)
+	httpStatusCode, err := con.client.do(ctx, req, &entries, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -211,7 +211,7 @@ func (con *contentService) getFile(
 	}
 
 	entry := new(Entry)
-	httpStatusCode, err := con.client.do(ctx, req, entry)
+	httpStatusCode, err := con.client.do(ctx, req, entry, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -264,7 +264,7 @@ func (con *contentService) getFiles(ctx context.Context,
 	}
 
 	var entries []*Entry
-	httpStatusCode, err := con.client.do(ctx, req, &entries)
+	httpStatusCode, err := con.client.do(ctx, req, &entries, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -293,7 +293,7 @@ func (con *contentService) getHistory(ctx context.Context,
 	}
 
 	var commits []*Commit
-	httpStatusCode, err := con.client.do(ctx, req, &commits)
+	httpStatusCode, err := con.client.do(ctx, req, &commits, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -331,7 +331,7 @@ func (con *contentService) getDiff(ctx context.Context,
 	}
 
 	change := new(Change)
-	httpStatusCode, err := con.client.do(ctx, req, change)
+	httpStatusCode, err := con.client.do(ctx, req, change, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -367,7 +367,7 @@ func (con *contentService) getDiffs(ctx context.Context,
 	}
 
 	var changes []*Change
-	httpStatusCode, err := con.client.do(ctx, req, &changes)
+	httpStatusCode, err := con.client.do(ctx, req, &changes, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -404,7 +404,7 @@ func (con *contentService) push(ctx context.Context, projectName, repoName, base
 	}
 
 	pushResult := new(PushResult)
-	httpStatusCode, err := con.client.do(ctx, req, pushResult)
+	httpStatusCode, err := con.client.do(ctx, req, pushResult, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}

--- a/content_service_test.go
+++ b/content_service_test.go
@@ -257,7 +257,7 @@ func TestPush(t *testing.T) {
 		testURLQuery(t, r, "revision", "-1")
 
 		var reqBody push
-		json.NewDecoder(r.Body).Decode(&reqBody)
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
 		changes := []*Change{{Path: "/a.json", Type: UpsertJSON, Content: map[string]interface{}{"a": "b"}}}
 		want := push{CommitMessage: &CommitMessage{Summary: "Add a.json"}, Changes: changes}
 		if !reflect.DeepEqual(reqBody, want) {
@@ -286,7 +286,7 @@ func TestPush_TwoFiles(t *testing.T) {
 		testURLQuery(t, r, "revision", "-1")
 
 		var reqBody push
-		json.NewDecoder(r.Body).Decode(&reqBody)
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
 		changes := []*Change{{Path: "/a.json", Type: UpsertJSON, Content: map[string]interface{}{"a": "b"}},
 			{Path: "/b.txt", Type: UpsertText, Content: "myContent"}}
 		want := push{CommitMessage: &CommitMessage{Summary: "Add a.json and b.txt"}, Changes: changes}

--- a/dogma.go
+++ b/dogma.go
@@ -323,7 +323,7 @@ func (c *Client) do(ctx context.Context,
 
 	// handling status code
 	startAt = time.Now()
-	if !watchRequest || statusCode != 304 {
+	if !watchRequest || statusCode != http.StatusNotModified {
 		if statusCode < 200 || statusCode >= 300 {
 			errorMessage := &errorMessage{}
 

--- a/dogma.go
+++ b/dogma.go
@@ -279,7 +279,8 @@ func drainupAndCloseResponseBody(body io.ReadCloser) {
 	}
 }
 
-func (c *Client) do(ctx context.Context, req *http.Request, resContent interface{}) (statusCode int, err error) {
+func (c *Client) do(ctx context.Context,
+	req *http.Request, resContent interface{}, watchRequest bool) (statusCode int, err error) {
 	req = req.WithContext(ctx)
 
 	// prepare metrics
@@ -322,19 +323,21 @@ func (c *Client) do(ctx context.Context, req *http.Request, resContent interface
 
 	// handling status code
 	startAt = time.Now()
-	if statusCode < 200 || statusCode >= 300 {
-		errorMessage := &errorMessage{}
+	if !watchRequest || statusCode != 304 {
+		if statusCode < 200 || statusCode >= 300 {
+			errorMessage := &errorMessage{}
 
-		err = json.NewDecoder(res.Body).Decode(errorMessage)
-		if err != nil {
-			err = fmt.Errorf("status: %v", statusCode)
-		} else {
-			err = fmt.Errorf("%s (status: %v)", errorMessage.Message, statusCode)
-		}
-	} else if resContent != nil {
-		err = json.NewDecoder(res.Body).Decode(resContent)
-		if err == io.EOF { // empty response body
-			err = nil
+			err = json.NewDecoder(res.Body).Decode(errorMessage)
+			if err != nil {
+				err = fmt.Errorf("status: %v", statusCode)
+			} else {
+				err = fmt.Errorf("%s (status: %v)", errorMessage.Message, statusCode)
+			}
+		} else if resContent != nil {
+			err = json.NewDecoder(res.Body).Decode(resContent)
+			if err == io.EOF { // empty response body
+				err = nil
+			}
 		}
 	}
 

--- a/dogma_test.go
+++ b/dogma_test.go
@@ -231,7 +231,7 @@ func TestNewClientWithToken_h2c(t *testing.T) {
 	hello := &helloArmeria{}
 
 	defer res.Body.Close()
-	json.NewDecoder(res.Body).Decode(hello)
+	_ = json.NewDecoder(res.Body).Decode(hello)
 	testString(t, hello.Hello, "Armeria", "hello")
 }
 
@@ -257,7 +257,7 @@ func TestNewClientWithToken_h1c(t *testing.T) {
 	hello := &helloArmeria{}
 
 	defer res.Body.Close()
-	json.NewDecoder(res.Body).Decode(hello)
+	_ = json.NewDecoder(res.Body).Decode(hello)
 	testString(t, hello.Hello, "Armeria", "hello")
 }
 

--- a/project_service.go
+++ b/project_service.go
@@ -43,7 +43,7 @@ func (p *projectService) create(ctx context.Context, name string) (*Project, int
 	}
 
 	project := new(Project)
-	httpStatusCode, err := p.client.do(ctx, req, project)
+	httpStatusCode, err := p.client.do(ctx, req, project, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -58,7 +58,7 @@ func (p *projectService) remove(ctx context.Context, name string) (int, error) {
 		return UnknownHttpStatusCode, err
 	}
 
-	httpStatusCode, err := p.client.do(ctx, req, nil)
+	httpStatusCode, err := p.client.do(ctx, req, nil, false)
 	if err != nil {
 		return httpStatusCode, err
 	}
@@ -74,7 +74,7 @@ func (p *projectService) unremove(ctx context.Context, name string) (*Project, i
 	}
 
 	project := new(Project)
-	httpStatusCode, err := p.client.do(ctx, req, project)
+	httpStatusCode, err := p.client.do(ctx, req, project, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -90,7 +90,7 @@ func (p *projectService) list(ctx context.Context) ([]*Project, int, error) {
 	}
 
 	var projects []*Project
-	httpStatusCode, err := p.client.do(ctx, req, &projects)
+	httpStatusCode, err := p.client.do(ctx, req, &projects, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -106,7 +106,7 @@ func (p *projectService) listRemoved(ctx context.Context) ([]*Project, int, erro
 	}
 
 	var projects []*Project
-	httpStatusCode, err := p.client.do(ctx, req, &projects)
+	httpStatusCode, err := p.client.do(ctx, req, &projects, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}

--- a/project_service_test.go
+++ b/project_service_test.go
@@ -34,7 +34,7 @@ func TestCreateProject(t *testing.T) {
 		testAuthorization(t, r)
 
 		project := new(Project)
-		json.NewDecoder(r.Body).Decode(project)
+		_ = json.NewDecoder(r.Body).Decode(project)
 		if !reflect.DeepEqual(project, input) {
 			t.Errorf("Request body = %+v, want %+v", project, input)
 		}

--- a/repository_service.go
+++ b/repository_service.go
@@ -40,7 +40,7 @@ func (r *repositoryService) create(ctx context.Context, projectName, repoName st
 	}
 
 	repo := new(Repository)
-	httpStatusCode, err := r.client.do(ctx, req, repo)
+	httpStatusCode, err := r.client.do(ctx, req, repo, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -56,7 +56,7 @@ func (r *repositoryService) remove(ctx context.Context, projectName, repoName st
 		return UnknownHttpStatusCode, err
 	}
 
-	httpStatusCode, err := r.client.do(ctx, req, nil)
+	httpStatusCode, err := r.client.do(ctx, req, nil, false)
 	if err != nil {
 		return httpStatusCode, err
 	}
@@ -72,7 +72,7 @@ func (r *repositoryService) unremove(ctx context.Context, projectName, repoName 
 	}
 
 	repo := new(Repository)
-	httpStatusCode, err := r.client.do(ctx, req, repo)
+	httpStatusCode, err := r.client.do(ctx, req, repo, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -88,7 +88,7 @@ func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Re
 	}
 
 	var repos []*Repository
-	httpStatusCode, err := r.client.do(ctx, req, &repos)
+	httpStatusCode, err := r.client.do(ctx, req, &repos, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -104,7 +104,7 @@ func (r *repositoryService) listRemoved(ctx context.Context, projectName string)
 	}
 
 	var repos []*Repository
-	httpStatusCode, err := r.client.do(ctx, req, &repos)
+	httpStatusCode, err := r.client.do(ctx, req, &repos, false)
 	if err != nil {
 		return nil, httpStatusCode, err
 	}
@@ -121,7 +121,7 @@ func (r *repositoryService) normalizeRevision(
 	}
 
 	rev := new(rev)
-	httpStatusCode, err := r.client.do(ctx, req, rev)
+	httpStatusCode, err := r.client.do(ctx, req, rev, false)
 	if err != nil {
 		return -1, httpStatusCode, err
 	}

--- a/repository_service_test.go
+++ b/repository_service_test.go
@@ -34,7 +34,7 @@ func TestCreateRepository(t *testing.T) {
 		testAuthorization(t, r)
 
 		repo := new(Repository)
-		json.NewDecoder(r.Body).Decode(repo)
+		_ = json.NewDecoder(r.Body).Decode(repo)
 		if !reflect.DeepEqual(repo, input) {
 			t.Errorf("Request body = %+v, want %+v", repo, input)
 		}

--- a/watch_service.go
+++ b/watch_service.go
@@ -358,7 +358,7 @@ func (w *Watcher) doWatch() {
 		return
 	}
 
-	if watchResult.HttpStatusCode != 304 {
+	if watchResult.HttpStatusCode != http.StatusNotModified {
 		// converting watch result and feed back to initial value channel if needed
 		if w.isInitialValueChSet == 0 && atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
 			// The initial latest is set for the first time. So write the value to initialValueCh as well.

--- a/watch_service.go
+++ b/watch_service.go
@@ -57,7 +57,7 @@ func (ws *watchService) watchFile(
 
 	u := fmt.Sprintf("%vprojects/%v/repos/%v/contents%v", defaultPathPrefix, projectName, repoName, query.Path)
 	v := &url.Values{}
-	if query != nil && query.Type == JSONPath {
+	if query.Type == JSONPath {
 		if err := setJSONPaths(v, query.Path, query.Expressions); err != nil {
 			return &WatchResult{Err: err}
 		}
@@ -113,7 +113,7 @@ func (ws *watchService) watchRequest(
 	defer cancel()
 
 	watchResult := new(WatchResult)
-	httpStatusCode, err := ws.client.do(reqCtx, req, watchResult)
+	httpStatusCode, err := ws.client.do(reqCtx, req, watchResult, true)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			err = fmt.Errorf("watch request timeout: %.3f second(s)", timeout.Seconds())
@@ -358,21 +358,23 @@ func (w *Watcher) doWatch() {
 		return
 	}
 
-	// converting watch result and feed back to initial value channel if needed
-	if w.isInitialValueChSet == 0 && atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
-		// The initial latest is set for the first time. So write the value to initialValueCh as well.
-		w.initialValueCh <- watchResult
+	if watchResult.HttpStatusCode != 304 {
+		// converting watch result and feed back to initial value channel if needed
+		if w.isInitialValueChSet == 0 && atomic.CompareAndSwapInt32(&w.isInitialValueChSet, 0, 1) {
+			// The initial latest is set for the first time. So write the value to initialValueCh as well.
+			w.initialValueCh <- watchResult
+		}
+
+		// store latest
+		w.latest.Store(watchResult)
+
+		// log latest revision
+		log.Debugf("Watcher noticed updated file: %s/%s%s, rev=%v",
+			w.projectName, w.repoName, w.pathPattern, watchResult.Revision)
+
+		// notify listener
+		w.notifyListeners()
 	}
-
-	// store latest
-	w.latest.Store(watchResult)
-
-	// log latest revision
-	log.Debugf("Watcher noticed updated file: %s/%s%s, rev=%v",
-		w.projectName, w.repoName, w.pathPattern, watchResult.Revision)
-
-	// notify listener
-	w.notifyListeners()
 
 	// wait for next attempt
 	w.numAttemptsSoFar = 0

--- a/watch_service_test.go
+++ b/watch_service_test.go
@@ -33,6 +33,8 @@ func TestWatchFile(t *testing.T) {
 	c, mux, teardown := setup()
 	defer teardown()
 
+	notModifiedResponse := true
+
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, http.MethodGet)
@@ -41,7 +43,12 @@ func TestWatchFile(t *testing.T) {
 
 			// Let's pretend that the content is modified after 100 Millisecond.
 			time.Sleep(100 * time.Millisecond)
-			fmt.Fprint(w, response)
+			if notModifiedResponse {
+				w.WriteHeader(304)
+				notModifiedResponse = false;
+			} else {
+				fmt.Fprint(w, response)
+			}
 		})
 
 	query := &Query{Path: "/a.json", Type: Identity}
@@ -127,8 +134,8 @@ func TestWatcher(t *testing.T) {
 	listener1 := func(value WatchResult) { myCh1 <- value }
 	listener2 := func(value WatchResult) { myCh2 <- value }
 
-	fw.Watch(listener1)
-	fw.Watch(listener2)
+	_ = fw.Watch(listener1)
+	_ = fw.Watch(listener2)
 
 	want := 2
 	for i := 0; i < 5; i++ {
@@ -144,7 +151,7 @@ func testChannelValue(t *testing.T, myCh <-chan WatchResult, want int) {
 		aStruct := struct {
 			A int `json:"a"`
 		}{}
-		json.Unmarshal(value.Entry.Content, &aStruct)
+		_ = json.Unmarshal(value.Entry.Content, &aStruct)
 		if aStruct.A != want {
 			t.Errorf("watch returned: %v, want %v", aStruct.A, want)
 		}
@@ -176,7 +183,7 @@ func TestWatcher_convertingValueFunc(t *testing.T) {
 
 	myCh := make(chan WatchResult, 128)
 	listener := func(value WatchResult) { myCh <- value }
-	fw.Watch(listener)
+	_ = fw.Watch(listener)
 
 	want := 2
 	for i := 0; i < 10; i++ {
@@ -185,7 +192,7 @@ func TestWatcher_convertingValueFunc(t *testing.T) {
 			aStruct := struct {
 				A int `json:"a"`
 			}{}
-			json.Unmarshal(value.Entry.Content, &aStruct)
+			_ = json.Unmarshal(value.Entry.Content, &aStruct)
 			if aStruct.A != want {
 				t.Errorf("watch returned: %v, want %v", aStruct.A, want)
 			}
@@ -280,7 +287,7 @@ func TestRepoWatcher(t *testing.T) {
 
 	myCh := make(chan int, 128)
 	listener := func(value WatchResult) { myCh <- value.Revision }
-	fw.Watch(listener)
+	_ = fw.Watch(listener)
 
 	want := 2
 	for i := 0; i < 5; i++ {
@@ -318,7 +325,7 @@ func TestRepoWatcherInvalidPathPattern(t *testing.T) {
 
 		myCh := make(chan int, 128)
 		listener := func(value WatchResult) { myCh <- value.Revision }
-		fw.Watch(listener)
+		_ = fw.Watch(listener)
 
 		for i := 0; i < 2; i++ {
 			select {

--- a/watch_service_test.go
+++ b/watch_service_test.go
@@ -44,7 +44,7 @@ func TestWatchFile(t *testing.T) {
 			// Let's pretend that the content is modified after 100 Millisecond.
 			time.Sleep(100 * time.Millisecond)
 			if notModifiedResponse {
-				w.WriteHeader(304)
+				w.WriteHeader(http.StatusNotModified)
 				notModifiedResponse = false;
 			} else {
 				fmt.Fprint(w, response)


### PR DESCRIPTION
Motivation:
`304` is not an error status when watching a file or repository, but we were not handling correctly.

Modifications:
- Do not propagte the `WatchResult` when `304` and retry watching silently
- Misc
  - Ignore unhandled error explicitly in the test code

Result:
- Behave same with the client of Java version