### PR TITLE
NO-ISSUE Optimize watch service

### DIFF
--- a/watch_service.go
+++ b/watch_service.go
@@ -262,7 +262,7 @@ func (w *Watcher) Watch(listener WatchListener) error {
 	ch := make(chan *WatchResult, 32)
 	go w.notifier(listener, ch)
 
-	// check latest and give to notifer (via channel) asap
+	// check the latest value and give it to the notifier asap
 	if latest := w.Latest(); latest.Err == nil {
 		select {
 		case <-w.watchCTX.Done():


### PR DESCRIPTION
This PR would refactor some code and optimize things:
1. Return latest value to listener asap when the value arrived
2. Watch service is now (fully) lock-free, thread safe. No mutex anymore. Heavy users enjoy performance gain, less gc stress