### PR TITLE
Fix not to indent when the content is not JSON object

### DIFF
--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -49,15 +49,7 @@ func (gf *getFileCommand) execute(c *cli.Context) error {
 	defer fd.Close()
 
 	if entry.Type == centraldogma.JSON {
-		var b []byte
-		if isJSON(entry.Content) {
-			b, err = marshalIndent(entry.Content)
-			if err != nil {
-				return err
-			}
-		} else {
-			b = entry.Content
-		}
+		b := safeMarshalIndent(entry.Content)
 		if _, err = fd.Write(b); err != nil {
 			return err
 		}
@@ -88,15 +80,7 @@ func (cf *catFileCommand) execute(c *cli.Context) error {
 	}
 
 	if entry.Type == centraldogma.JSON {
-		var b []byte
-		if isJSON(entry.Content) {
-			b, err = marshalIndent(entry.Content)
-			if err != nil {
-				return err
-			}
-		} else {
-			b = entry.Content
-		}
+		b := safeMarshalIndent(entry.Content)
 		fmt.Printf("%s\n", string(b))
 	} else if entry.Type == centraldogma.Text { //
 		fmt.Printf("%s\n", string(entry.Content))

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -49,11 +49,18 @@ func (gf *getFileCommand) execute(c *cli.Context) error {
 	defer fd.Close()
 
 	if entry.Type == centraldogma.JSON {
-		b, err := marshalIndent(entry.Content)
-		if err != nil {
+		var b []byte
+		if isJSON(entry.Content) {
+			b, err = marshalIndent(entry.Content)
+			if err != nil {
+				return err
+			}
+		} else {
+			b = entry.Content
+		}
+		if _, err = fd.Write(b); err != nil {
 			return err
 		}
-		fd.Write(b)
 	} else if entry.Type == centraldogma.Text {
 		_, err = fd.Write(entry.Content)
 		if err != nil {
@@ -81,9 +88,14 @@ func (cf *catFileCommand) execute(c *cli.Context) error {
 	}
 
 	if entry.Type == centraldogma.JSON {
-		b, err := marshalIndent(entry.Content)
-		if err != nil {
-			return err
+		var b []byte
+		if isJSON(entry.Content) {
+			b, err = marshalIndent(entry.Content)
+			if err != nil {
+				return err
+			}
+		} else {
+			b = entry.Content
 		}
 		fmt.Printf("%s\n", string(b))
 	} else if entry.Type == centraldogma.Text { //

--- a/internal/app/dogma/util.go
+++ b/internal/app/dogma/util.go
@@ -277,15 +277,10 @@ func marshalIndentObject(data interface{}) ([]byte, error) {
 }
 
 func safeMarshalIndent(src []byte) ([]byte) {
-	if isJSON(src) {
+	if json.Valid(src) {
 		dst := new(bytes.Buffer)
 		_ = json.Indent(dst, src, "", "  ")
 		return dst.Bytes()
 	}
 	return src
-}
-
-func isJSON(b []byte) bool {
-	var holder map[string]interface{}
-	return json.Unmarshal(b, &holder) == nil
 }

--- a/internal/app/dogma/util.go
+++ b/internal/app/dogma/util.go
@@ -225,11 +225,15 @@ func putIntoTempFile(entry *centraldogma.Entry) (string, error) {
 	}
 	defer fd.Close()
 	if entry.Type == centraldogma.JSON {
-		b, err := marshalIndent(entry.Content)
-		if err != nil {
-			return "", err
+		var b []byte
+		if isJSON(entry.Content) {
+			b, err = marshalIndent(entry.Content)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			b = entry.Content
 		}
-
 		if _, err := fd.Write(b); err != nil {
 			return "", err
 		}
@@ -271,6 +275,11 @@ func newUpsertChangeFromFile(fileName, repositoryPath string) (*centraldogma.Cha
 		change.Type = centraldogma.UpsertText
 	}
 	return change, nil
+}
+
+func isJSON(b []byte) bool {
+	var holder map[string]interface{}
+	return json.Unmarshal(b, &holder) == nil
 }
 
 func marshalIndentObject(data interface{}) ([]byte, error) {

--- a/internal/app/dogma/watch_cmd.go
+++ b/internal/app/dogma/watch_cmd.go
@@ -69,17 +69,7 @@ func (wc *watchCommand) execute(c *cli.Context) error {
 				repo.projName, repo.repoName, repo.path, revision)
 			content := ""
 			if strings.HasSuffix(strings.ToLower(repo.path), ".json") {
-				var b []byte
-				if isJSON(watchResult.Entry.Content) {
-					b, err = marshalIndent(watchResult.Entry.Content)
-					if err != nil {
-						fmt.Printf("Failed to print the content: %v", string(watchResult.Entry.Content))
-						return
-					}
-				} else {
-					b = watchResult.Entry.Content
-				}
-				content = string(b)
+				content = string(safeMarshalIndent(watchResult.Entry.Content))
 			} else {
 				content = string(watchResult.Entry.Content)
 			}


### PR DESCRIPTION
Motivation:
Currently, we indent JSON content if the `EntryType` is `JSON`.
However, the content can be just a string when we use JSON path.

Modification:
- Do not indent when the content is not JSON object

Result:
- Fix #36
- You no longer see parsing error when fetching JSON content using JSON path