### PR TITLE
Fix possible context leak in watch_cmd

### DIFF
--- a/internal/app/dogma/watch_cmd.go
+++ b/internal/app/dogma/watch_cmd.go
@@ -53,6 +53,7 @@ func (wc *watchCommand) execute(c *cli.Context) error {
 
 	// prepare context
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	done := make(chan struct{}, 2)
 	notifyDone := func() {
@@ -104,9 +105,6 @@ func (wc *watchCommand) execute(c *cli.Context) error {
 
 	// wait until notified to done channel
 	<-done
-
-	// cancel context and leave
-	cancel()
 
 	return nil
 }


### PR DESCRIPTION
This patch addresses the following `go vet` warning.

```
$ go vet
./watch_cmd.go:55:2: the cancel function is not used on all paths
(possible context leak)
./watch_cmd.go:88:3: this return statement may be reached without using
the cancel var defined on line 55
```