### PR TITLE
Add `--listener` option to dogma watch command

### DIFF
--- a/internal/app/dogma/cli_cmds.go
+++ b/internal/app/dogma/cli_cmds.go
@@ -57,7 +57,7 @@ var streamingFlag = cli.BoolFlag{
 
 var listenerFlag = cli.StringFlag{
 	Name:  "listener, l",
-	Usage: "Specifies the executable path that handles watch events",
+	Usage: "Specifies the `executable` path that handles watch events",
 }
 
 var printFormatFlags = []cli.Flag{
@@ -228,8 +228,21 @@ func CLICommands() []cli.Command {
 			},
 		},
 		{
-			Name:      "watch",
-			Usage:     "Watches a file in the path",
+			Name:  "watch",
+			Usage: "Watches a file in the path",
+			Description: `Watch events are printed to stdout by default.
+   You can customize this behavior by using --listener <executable> option.
+   The command you specified as <executable> can read updated content body through its STDIN.
+   Other meta data about the watch event are available via environment variables below.
+
+     DOGMA_WATCH_EVENT_PATH - The path to the file you're watching
+     DOGMA_WATCH_EVENT_CONTENT_TYPE - The content type of the file, JSON or TEXT
+     DOGMA_WATCH_EVENT_REV - The revision number of the watch event
+     DOGMA_WATCH_EVENT_URL - The URL of the target file
+
+   e.g.
+     # Print foo.json content when it gets updated
+     dogma watch --listener cat /pj/repo/foo.json`,
 			ArgsUsage: "<project_name>/<repository_name>/<path>",
 			Flags:     []cli.Flag{revisionFlag, jsonPathFlag, streamingFlag, listenerFlag},
 			Action: func(c *cli.Context) error {

--- a/internal/app/dogma/cli_cmds.go
+++ b/internal/app/dogma/cli_cmds.go
@@ -242,7 +242,9 @@ func CLICommands() []cli.Command {
 
    e.g.
      # Print foo.json content when it gets updated
-     dogma watch --listener cat /pj/repo/foo.json`,
+     dogma watch --listener cat /pj/repo/foo.json
+
+   Please note that --listener option is not tested well on Windows.`,
 			ArgsUsage: "<project_name>/<repository_name>/<path>",
 			Flags:     []cli.Flag{revisionFlag, jsonPathFlag, streamingFlag, listenerFlag},
 			Action: func(c *cli.Context) error {

--- a/internal/app/dogma/cli_cmds.go
+++ b/internal/app/dogma/cli_cmds.go
@@ -242,9 +242,7 @@ func CLICommands() []cli.Command {
 
    e.g.
      # Print foo.json content when it gets updated
-     dogma watch --listener cat /pj/repo/foo.json
-
-   Please note that --listener option is not tested well on Windows.`,
+     dogma watch --listener cat /pj/repo/foo.json`,
 			ArgsUsage: "<project_name>/<repository_name>/<path>",
 			Flags:     []cli.Flag{revisionFlag, jsonPathFlag, streamingFlag, listenerFlag},
 			Action: func(c *cli.Context) error {

--- a/internal/app/dogma/cli_cmds.go
+++ b/internal/app/dogma/cli_cmds.go
@@ -55,6 +55,11 @@ var streamingFlag = cli.BoolFlag{
 	Usage: "Specifies whether to keep watching the file",
 }
 
+var listenerFlag = cli.StringFlag{
+	Name:  "listener, l",
+	Usage: "Specifies the executable path that handles watch events",
+}
+
 var printFormatFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:   "pretty",
@@ -226,7 +231,7 @@ func CLICommands() []cli.Command {
 			Name:      "watch",
 			Usage:     "Watches a file in the path",
 			ArgsUsage: "<project_name>/<repository_name>/<path>",
-			Flags:     []cli.Flag{revisionFlag, jsonPathFlag, streamingFlag},
+			Flags:     []cli.Flag{revisionFlag, jsonPathFlag, streamingFlag, listenerFlag},
 			Action: func(c *cli.Context) error {
 				command, err := newWatchCommand(c)
 				if err != nil {

--- a/internal/app/dogma/main.go
+++ b/internal/app/dogma/main.go
@@ -70,7 +70,9 @@ func main() {
 
 var commandHelpTemplate = `DESCRIPTION:
    {{if .Usage}}{{.Usage}}{{end}}
-
+   {{ if .Description}}
+   {{.Description}}
+   {{end }}
 USAGE:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
 

--- a/internal/app/dogma/watch_cmd.go
+++ b/internal/app/dogma/watch_cmd.go
@@ -30,10 +30,10 @@ import (
 )
 
 type watchCommand struct {
-	repo      repositoryRequestInfo
-	jsonPaths []string
-	streaming bool
-	listener  string
+	repo         repositoryRequestInfo
+	jsonPaths    []string
+	streaming    bool
+	listenerFile string
 }
 
 type listenerExecError struct {
@@ -60,7 +60,7 @@ func (wc *watchCommand) defaultListener(watchResult dogma.WatchResult) error {
 }
 
 func (wc *watchCommand) commandExecutionListener(watchResult dogma.WatchResult) error {
-	command := exec.Command(wc.listener)
+	command := exec.Command(wc.listenerFile)
 	command.Env = append(os.Environ(),
 		"DOGMA_WATCH_EVENT_PATH="+watchResult.Entry.Path,
 		"DOGMA_WATCH_EVENT_CONTENT_TYPE="+watchResult.Entry.Type.String(),
@@ -71,7 +71,7 @@ func (wc *watchCommand) commandExecutionListener(watchResult dogma.WatchResult) 
 	command.Stderr = os.Stderr
 	err := command.Run()
 	if err != nil {
-		return &listenerExecError{underlying: err, command: wc.listener}
+		return &listenerExecError{underlying: err, command: wc.listenerFile}
 	}
 	return nil
 }
@@ -113,7 +113,7 @@ func (wc *watchCommand) executeWithDogmaClient(c *cli.Context, client *dogma.Cli
 
 	listener := wc.defaultListener
 
-	if wc.listener != "" {
+	if wc.listenerFile != "" {
 		listener = wc.commandExecutionListener
 	}
 
@@ -157,5 +157,5 @@ func newWatchCommand(c *cli.Context) (Command, error) {
 		return nil, err
 	}
 
-	return &watchCommand{repo: repo, jsonPaths: c.StringSlice("jsonpath"), streaming: c.Bool("streaming"), listener: c.String("listener")}, nil
+	return &watchCommand{repo: repo, jsonPaths: c.StringSlice("jsonpath"), streaming: c.Bool("streaming"), listenerFile: c.String("listener")}, nil
 }

--- a/internal/app/dogma/watch_cmd.go
+++ b/internal/app/dogma/watch_cmd.go
@@ -15,10 +15,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
+	"strconv"
 	"strings"
 
 	dogma "go.linecorp.com/centraldogma"
@@ -30,14 +33,59 @@ type watchCommand struct {
 	repo      repositoryRequestInfo
 	jsonPaths []string
 	streaming bool
+	listener  string
+}
+
+type listenerExecError struct {
+	underlying error
+	command    string
+}
+
+func (e *listenerExecError) Error() string {
+	return fmt.Sprintf("failed to execute listener %s: %s", e.command, e.underlying.Error())
+}
+
+func (wc *watchCommand) defaultListener(watchResult dogma.WatchResult) error {
+	repo := wc.repo
+	fmt.Printf("Watcher noticed updated file: %s/%s%s, rev=%v\n",
+		repo.projName, repo.repoName, repo.path, watchResult.Revision)
+	content := ""
+	if strings.HasSuffix(strings.ToLower(repo.path), ".json") {
+		content = string(safeMarshalIndent(watchResult.Entry.Content))
+	} else {
+		content = string(watchResult.Entry.Content)
+	}
+	fmt.Printf("Content:\n%s\n", content)
+	return nil
+}
+
+func (wc *watchCommand) commandExecutionListener(watchResult dogma.WatchResult) error {
+	command := exec.Command(wc.listener)
+	command.Env = append(os.Environ(),
+		"DOGMA_WATCH_EVENT_PATH="+watchResult.Entry.Path,
+		"DOGMA_WATCH_EVENT_CONTENT_TYPE="+watchResult.Entry.Type.String(),
+		"DOGMA_WATCH_EVENT_REV="+strconv.Itoa(watchResult.Revision),
+		"DOGMA_WATCH_EVENT_URL="+watchResult.Entry.URL)
+	command.Stdin = bytes.NewReader(watchResult.Entry.Content)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	err := command.Run()
+	if err != nil {
+		return &listenerExecError{underlying: err, command: wc.listener}
+	}
+	return nil
 }
 
 func (wc *watchCommand) execute(c *cli.Context) error {
-	repo := wc.repo
-	client, err := newDogmaClient(c, repo.remoteURL)
+	client, err := newDogmaClient(c, wc.repo.remoteURL)
 	if err != nil {
 		return err
 	}
+	return wc.executeWithDogmaClient(c, client)
+}
+
+func (wc *watchCommand) executeWithDogmaClient(c *cli.Context, client *dogma.Client) error {
+	repo := wc.repo
 
 	normalizedRevision, _, err := client.NormalizeRevision(
 		context.Background(), repo.projName, repo.repoName, repo.revision)
@@ -55,37 +103,32 @@ func (wc *watchCommand) execute(c *cli.Context) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	done := make(chan struct{}, 2)
-	notifyDone := func() {
+	done := make(chan error, 2)
+	notifyDone := func(err error) {
 		select {
 		case <-ctx.Done():
-		case done <- struct{}{}: // notify
+		case done <- err: // notify
 		}
 	}
 
-	listener := func(watchResult dogma.WatchResult) {
-		revision := watchResult.Revision
-		if revision > normalizedRevision {
-			fmt.Printf("Watcher noticed updated file: %s/%s%s, rev=%v\n",
-				repo.projName, repo.repoName, repo.path, revision)
-			content := ""
-			if strings.HasSuffix(strings.ToLower(repo.path), ".json") {
-				content = string(safeMarshalIndent(watchResult.Entry.Content))
-			} else {
-				content = string(watchResult.Entry.Content)
-			}
-			fmt.Printf("Content:\n%s\n", content)
+	listener := wc.defaultListener
 
-			if !wc.streaming {
-				fw.Close()
-				notifyDone()
-			}
-		}
+	if wc.listener != "" {
+		listener = wc.commandExecutionListener
 	}
 
 	// start watching
-	err = fw.Watch(listener)
+	err = fw.Watch(func(watchResult dogma.WatchResult) {
+		if watchResult.Revision > normalizedRevision {
+			err := listener(watchResult)
+			if err != nil || !wc.streaming {
+				fw.Close()
+				notifyDone(err)
+			}
+		}
+	})
 	if err != nil {
+		fw.Close()
 		return err
 	}
 
@@ -99,14 +142,12 @@ func (wc *watchCommand) execute(c *cli.Context) error {
 		case <-signalChan:
 			fmt.Println("\nReceived an interrupt, stopping watcher...")
 			fw.Close()
-			notifyDone()
+			notifyDone(nil)
 		}
 	}()
 
 	// wait until notified to done channel
-	<-done
-
-	return nil
+	return <-done
 }
 
 // newWatchCommand creates the watchCommand.
@@ -116,5 +157,5 @@ func newWatchCommand(c *cli.Context) (Command, error) {
 		return nil, err
 	}
 
-	return &watchCommand{repo: repo, jsonPaths: c.StringSlice("jsonpath"), streaming: c.Bool("streaming")}, nil
+	return &watchCommand{repo: repo, jsonPaths: c.StringSlice("jsonpath"), streaming: c.Bool("streaming"), listener: c.String("listener")}, nil
 }

--- a/internal/app/dogma/watch_cmd_test.go
+++ b/internal/app/dogma/watch_cmd_test.go
@@ -1,0 +1,152 @@
+// Copyright 2021 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	dogma "go.linecorp.com/centraldogma"
+)
+
+func mockedCentralDogmaServer(entry dogma.Entry) *httptest.Server {
+	revision := entry.Revision
+	ts := httptest.NewUnstartedServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/revision/-1") {
+				fmt.Fprintf(w, `{"revision": %d}`, revision)
+				return
+			}
+
+			fmt.Fprintf(w, `{"revision": %[1]d,
+			"entry": {"revision": %[1]d, "path": "%s", "content": %s, "type": "%s", "url": "%s"}}`,
+				revision+1, entry.Path, string(entry.Content), entry.Type.String(), entry.URL)
+		}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	return ts
+}
+
+func runCommandAndCaptureStdout(f func()) []byte {
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = originalStdout }()
+
+	f()
+
+	w.Close()
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func TestListenerOption(t *testing.T) {
+	if _, err := exec.LookPath("cat"); err != nil {
+		t.Skipf("skipping %s due to a lack of cat command", t.Name())
+
+	}
+	if _, err := exec.LookPath("env"); err != nil {
+		t.Skipf("skipping %s due to a lack of env command", t.Name())
+	}
+
+	entry := dogma.Entry{
+		Content:  []byte(`{"foo":"FOO"}`),
+		Path:     "/foo.json",
+		Revision: 2,
+		Type:     dogma.JSON,
+		URL:      "/api/v1/projects/test/repos/test/contents/foo.json",
+	}
+	server := mockedCentralDogmaServer(entry)
+	defer server.Close()
+
+	client, _ := dogma.NewClientWithToken(server.URL, "anonymous", server.Client().Transport)
+
+	wc := watchCommand{
+		repo: repositoryRequestInfo{
+			remoteURL: server.URL,
+			projName:  "test",
+			repoName:  "test",
+			path:      "/foo.json",
+			revision:  "-1",
+		},
+		listener: "cat",
+	}
+
+	out := runCommandAndCaptureStdout(func() { wc.executeWithDogmaClient(nil, client) })
+
+	if !bytes.Equal(out, entry.Content) {
+		t.Errorf("Got output %s; want %s", string(out), string(entry.Content))
+	}
+
+	wc.listener = "env"
+
+	out = runCommandAndCaptureStdout(func() { wc.executeWithDogmaClient(nil, client) })
+	env := string(out)
+
+	if !strings.Contains(env, "DOGMA_WATCH_EVENT_PATH="+entry.Path) {
+		t.Errorf("No path information found in environment %s", env)
+	}
+	if !strings.Contains(env, "DOGMA_WATCH_EVENT_REV="+strconv.FormatInt(entry.Revision+1, 10)) {
+		t.Errorf("No revision information found in environment %s", env)
+	}
+	if !strings.Contains(env, "DOGMA_WATCH_EVENT_CONTENT_TYPE="+entry.Type.String()) {
+		t.Errorf("No content type information found in environment %s", env)
+	}
+	if !strings.Contains(env, "DOGMA_WATCH_EVENT_URL="+entry.URL) {
+		t.Errorf("No url information found in environment %s", env)
+	}
+}
+
+func TestInvalidListenerOption(t *testing.T) {
+	entry := dogma.Entry{
+		Content:  []byte(`{"foo":"FOO"}`),
+		Path:     "/foo.json",
+		Revision: 2,
+		Type:     dogma.JSON,
+		URL:      "/api/v1/projects/test/repos/test/contents/foo.json",
+	}
+	server := mockedCentralDogmaServer(entry)
+	defer server.Close()
+
+	client, _ := dogma.NewClientWithToken(server.URL, "anonymous", server.Client().Transport)
+
+	wc := watchCommand{
+		repo: repositoryRequestInfo{
+			remoteURL: server.URL,
+			projName:  "test",
+			repoName:  "test",
+			path:      "/foo.json",
+			revision:  "-1",
+		},
+		listener: "XYZ NO SUCH COMMAND",
+	}
+
+	err := wc.executeWithDogmaClient(nil, client)
+	if _, ok := err.(*listenerExecError); !ok {
+		t.Errorf("Didn't get listenerExecError; want = %v", err)
+	}
+
+}

--- a/internal/app/dogma/watch_cmd_test.go
+++ b/internal/app/dogma/watch_cmd_test.go
@@ -92,7 +92,7 @@ func TestListenerOption(t *testing.T) {
 			path:      "/foo.json",
 			revision:  "-1",
 		},
-		listener: "cat",
+		listenerFile: "cat",
 	}
 
 	out := runCommandAndCaptureStdout(func() { wc.executeWithDogmaClient(nil, client) })
@@ -101,7 +101,7 @@ func TestListenerOption(t *testing.T) {
 		t.Errorf("Got output %s; want %s", string(out), string(entry.Content))
 	}
 
-	wc.listener = "env"
+	wc.listenerFile = "env"
 
 	out = runCommandAndCaptureStdout(func() { wc.executeWithDogmaClient(nil, client) })
 	env := string(out)
@@ -141,7 +141,7 @@ func TestInvalidListenerOption(t *testing.T) {
 			path:      "/foo.json",
 			revision:  "-1",
 		},
-		listener: "XYZ NO SUCH COMMAND",
+		listenerFile: "XYZ NO SUCH COMMAND",
 	}
 
 	err := wc.executeWithDogmaClient(nil, client)

--- a/internal/app/dogma/watch_cmd_test.go
+++ b/internal/app/dogma/watch_cmd_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -63,6 +64,9 @@ func runCommandAndCaptureStdout(f func()) []byte {
 }
 
 func TestListenerOption(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on windows because there's no handy commands for testing")
+	}
 	if _, err := exec.LookPath("cat"); err != nil {
 		t.Skipf("skipping %s due to a lack of cat command", t.Name())
 

--- a/internal/app/dogma/watch_cmd_test.go
+++ b/internal/app/dogma/watch_cmd_test.go
@@ -42,7 +42,6 @@ func mockedCentralDogmaServer(entry dogma.Entry) *httptest.Server {
 			"entry": {"revision": %[1]d, "path": "%s", "content": %s, "type": "%s", "url": "%s"}}`,
 				revision+1, entry.Path, string(entry.Content), entry.Type.String(), entry.URL)
 		}))
-	ts.EnableHTTP2 = true
 	ts.StartTLS()
 	return ts
 }


### PR DESCRIPTION
Motivation:

Related to #40.

We're managing several middlewares (e.g. [prometheus](https://prometheus.io/), [HBase](https://hbase.apache.org/))
and we have had some configuration values in git repositories.

To make config-deploy process easier, we're going to put the config values to CentralDogma
so that each middleware host can fetch the latest config values quickly through watch API.

To keep config values on each middleware host in sync, we need a daemon application which
- runs on each middleware host
- watches target config values on CentralDogma repository
- synchronizes the local config file content with the updates on the repository

Of course, we can write a custom app using centraldogma library but
it'd be helpful if official cli tool can have a function to support such scenario.

Modifications:

- Add new option `--listener,-l` to dogma-watch command, that takes executable path as argument
- Add minimal test cases for the change

Result:

- Closes #40
- dogma cli users can handle centraldogma watch event by their custom script
  For example,

        dogma watch --listener myscript.sh --streaming /proj/repo/app_config.json

  `myscript.sh` gets watch event information through STDIN and environment variables like CGI.
  The content body of the watch target can be read from STDIN.
  The path, content_type, revision and url information can be accessed through env vars
  `DOGMA_WATCH_EVENT_PATH`, `DOGMA_WATCH_EVENT_CONTENT_TYPE`, `DOGMA_WATCH_EVENT_REV`, `DOGMA_WATCH_EVENT_URL` respectively.

Note:

In the issue #40, I propsed passing watch-event meta information through positional arguments (= $1, $2 ..) but I changed my mind.
If we adopt positional arguments, it might be difficult to keep compatibility when we change watch event structure.
That's why I use environment variables in this PR.
