### PR TITLE
fix : entry's revision type to int32

### DIFF
--- a/content_service.go
+++ b/content_service.go
@@ -49,7 +49,7 @@ type Entry struct {
 	Path       string       `json:"path"`
 	Type       EntryType    `json:"type"` // can be JSON, TEXT or DIRECTORY
 	Content    EntryContent `json:"content,omitempty"`
-	Revision   int64        `json:"revision,omitempty"`
+	Revision   int          `json:"revision,omitempty"`
 	URL        string       `json:"url,omitempty"`
 	ModifiedAt string       `json:"modifiedAt,omitempty"`
 }


### PR DESCRIPTION
based on #46 

test result

```bash
PASS
coverage: 76.7% of statements
ok      go.linecorp.com/centraldogma    25.960s coverage: 76.7% of statements
```