### PR TITLE
Add `--recursive` flag to dogma get command

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x, 1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.x, 1.16.x, 1.17.x, 1.18.x]
         platform: [ubuntu-latest]
         include:
           # include windows, but only with the latest Go version, since there

--- a/dogma.go
+++ b/dogma.go
@@ -429,12 +429,11 @@ func (c *Client) NormalizeRevision(
 
 // ListFiles returns the list of files that match the given path pattern. A path pattern is a variant of glob:
 //
-//     - "/**": find all files recursively
-//     - "*.json": find all JSON files recursively
-//     - "/foo/*.json": find all JSON files under the directory /foo
-//     - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
-//     - "*.json,/bar/*.txt": use comma to match any patterns
-//
+//   - "/**": find all files recursively
+//   - "*.json": find all JSON files recursively
+//   - "/foo/*.json": find all JSON files under the directory /foo
+//   - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
+//   - "*.json,/bar/*.txt": use comma to match any patterns
 func (c *Client) ListFiles(ctx context.Context,
 	projectName, repoName, revision, pathPattern string) (entries []*Entry, httpStatusCode int, err error) {
 	return c.content.listFiles(ctx, projectName, repoName, revision, pathPattern)
@@ -449,12 +448,11 @@ func (c *Client) GetFile(
 
 // GetFiles returns the files that match the given path pattern. A path pattern is a variant of glob:
 //
-//     - "/**": find all files recursively
-//     - "*.json": find all JSON files recursively
-//     - "/foo/*.json": find all JSON files under the directory /foo
-//     - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
-//     - "*.json,/bar/*.txt": use comma to match any patterns
-//
+//   - "/**": find all files recursively
+//   - "*.json": find all JSON files recursively
+//   - "/foo/*.json": find all JSON files under the directory /foo
+//   - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
+//   - "*.json,/bar/*.txt": use comma to match any patterns
 func (c *Client) GetFiles(ctx context.Context,
 	projectName, repoName, revision, pathPattern string) (entries []*Entry, httpStatusCode int, err error) {
 	return c.content.getFiles(ctx, projectName, repoName, revision, pathPattern)
@@ -463,11 +461,11 @@ func (c *Client) GetFiles(ctx context.Context,
 // GetHistory returns the history of the files that match the given path pattern. A path pattern is
 // a variant of glob:
 //
-//     - "/**": find all files recursively
-//     - "*.json": find all JSON files recursively
-//     - "/foo/*.json": find all JSON files under the directory /foo
-//     - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
-//     - "*.json,/bar/*.txt": use comma to match any patterns
+//   - "/**": find all files recursively
+//   - "*.json": find all JSON files recursively
+//   - "/foo/*.json": find all JSON files under the directory /foo
+//   - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
+//   - "*.json,/bar/*.txt": use comma to match any patterns
 //
 // If the from and to are not specified, this will return the history from the init to the latest revision.
 func (c *Client) GetHistory(ctx context.Context,
@@ -486,11 +484,11 @@ func (c *Client) GetDiff(ctx context.Context,
 // GetDiffs returns the diffs of the files that match the given path pattern. A path pattern is
 // a variant of glob:
 //
-//     - "/**": find all files recursively
-//     - "*.json": find all JSON files recursively
-//     - "/foo/*.json": find all JSON files under the directory /foo
-//     - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
-//     - "*.json,/bar/*.txt": use comma to match any patterns
+//   - "/**": find all files recursively
+//   - "*.json": find all JSON files recursively
+//   - "/foo/*.json": find all JSON files under the directory /foo
+//   - "/&#42;/foo.txt": find all files named foo.txt at the second depth level
+//   - "*.json,/bar/*.txt": use comma to match any patterns
 //
 // If the from and to are not specified, this will return the diffs from the init to the latest revision.
 func (c *Client) GetDiffs(ctx context.Context,
@@ -530,27 +528,27 @@ func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer
 // Manually closing returned channel is unsafe and may cause sending on closed channel error.
 // Usage:
 //
-//    query := &Query{Path: "/a.json", Type: Identity}
-//    ctx := context.Background()
-//    changes, closer, err := client.WatchFile(ctx, "foo", "bar", query, 2 * time.Minute)
-//    if err != nil {
-//		 panic(err)
-//    }
-//    defer closer() // stop watching and release underlying resources.
+//	   query := &Query{Path: "/a.json", Type: Identity}
+//	   ctx := context.Background()
+//	   changes, closer, err := client.WatchFile(ctx, "foo", "bar", query, 2 * time.Minute)
+//	   if err != nil {
+//			 panic(err)
+//	   }
+//	   defer closer() // stop watching and release underlying resources.
 //
-//    /* close(changes) */ // manually closing is unsafe, don't do this.
+//	   /* close(changes) */ // manually closing is unsafe, don't do this.
 //
-//    for {
-//        select {
-//          case <-ctx.Done():
-//             ...
+//	   for {
+//	       select {
+//	         case <-ctx.Done():
+//	            ...
 //
-//          case change := <-changes:
-//             // got change
-//             json.Unmarshal(change.Entry.Content, &expect)
-//             ...
-//        }
-//    }
+//	         case change := <-changes:
+//	            // got change
+//	            json.Unmarshal(change.Entry.Content, &expect)
+//	            ...
+//	       }
+//	   }
 func (c *Client) WatchFile(
 	ctx context.Context,
 	projectName, repoName string, query *Query,
@@ -577,27 +575,27 @@ func (c *Client) WatchFile(
 // Manually closing returned channel is unsafe and may cause sending on closed channel error.
 // Usage:
 //
-//    query := &Query{Path: "/a.json", Type: Identity}
-//    ctx := context.Background()
-//    changes, closer, err := client.WatchRepository(ctx, "foo", "bar", "/*.json", 2 * time.Minute)
-//    if err != nil {
-//		 panic(err)
-//    }
-//    defer closer() // stop watching and release underlying resources.
+//	   query := &Query{Path: "/a.json", Type: Identity}
+//	   ctx := context.Background()
+//	   changes, closer, err := client.WatchRepository(ctx, "foo", "bar", "/*.json", 2 * time.Minute)
+//	   if err != nil {
+//			 panic(err)
+//	   }
+//	   defer closer() // stop watching and release underlying resources.
 //
-//    /* close(changes) */ // manually closing is unsafe, don't do this.
+//	   /* close(changes) */ // manually closing is unsafe, don't do this.
 //
-//    for {
-//        select {
-//          case <-ctx.Done():
-//             ...
+//	   for {
+//	       select {
+//	         case <-ctx.Done():
+//	            ...
 //
-//          case change := <-changes:
-//             // got change
-//             json.Unmarshal(change.Entry.Content, &expect)
-//             ...
-//        }
-//    }
+//	         case change := <-changes:
+//	            // got change
+//	            json.Unmarshal(change.Entry.Content, &expect)
+//	            ...
+//	       }
+//	   }
 func (c *Client) WatchRepository(
 	ctx context.Context,
 	projectName, repoName, pathPattern string,
@@ -619,14 +617,14 @@ func (c *Client) WatchRepository(
 // FileWatcher returns a Watcher which notifies its listeners when the result of the given Query becomes
 // available or changes. For example:
 //
-//    query := &Query{Path: "/a.json", Type: Identity}
-//    watcher := client.FileWatcher("foo", "bar", query)
+//	query := &Query{Path: "/a.json", Type: Identity}
+//	watcher := client.FileWatcher("foo", "bar", query)
 //
-//    myCh := make(chan interface{})
-//    watcher.Watch(func(revision int, value interface{}) {
-//        myCh <- value
-//    })
-//    myValue := <-myCh
+//	myCh := make(chan interface{})
+//	watcher.Watch(func(revision int, value interface{}) {
+//	    myCh <- value
+//	})
+//	myValue := <-myCh
 func (c *Client) FileWatcher(projectName, repoName string, query *Query) (*Watcher, error) {
 	fw, err := c.watch.fileWatcher(context.Background(), projectName, repoName, query)
 	if err != nil {
@@ -639,13 +637,13 @@ func (c *Client) FileWatcher(projectName, repoName string, query *Query) (*Watch
 // RepoWatcher returns a Watcher which notifies its listeners when the repository that matched the given
 // pathPattern becomes available or changes. For example:
 //
-//    watcher := client.RepoWatcher("foo", "bar", "/*.json")
+//	watcher := client.RepoWatcher("foo", "bar", "/*.json")
 //
-//    myCh := make(chan interface{})
-//    watcher.Watch(func(revision int, value interface{}) {
-//        myCh <- value
-//    })
-//    myValue := <-myCh
+//	myCh := make(chan interface{})
+//	watcher.Watch(func(revision int, value interface{}) {
+//	    myCh <- value
+//	})
+//	myValue := <-myCh
 func (c *Client) RepoWatcher(projectName, repoName, pathPattern string) (*Watcher, error) {
 	rw, err := c.watch.repoWatcher(context.Background(), projectName, repoName, pathPattern)
 	if err != nil {
@@ -657,17 +655,19 @@ func (c *Client) RepoWatcher(projectName, repoName, pathPattern string) (*Watche
 
 // SetMetricCollector sets metric collector for the client.
 // For example, with Prometheus:
-//     config := centraldogma.DefaultMetricCollectorConfig("client_name")
-//     metricCollector := centraldogma.GlobalPrometheusMetricCollector(config)
-//     client.SetMetricCollector(metricCollector)
+//
+//	config := centraldogma.DefaultMetricCollectorConfig("client_name")
+//	metricCollector := centraldogma.GlobalPrometheusMetricCollector(config)
+//	client.SetMetricCollector(metricCollector)
 //
 // Or Statsd:
-//     config := centraldogma.DefaultMetricCollectorConfig("client_name")
-//     metricCollector, err := centraldogma.StatsdMetricCollector(config, "127.0.0.1:8125")
-//     if err != nil {
-//         panic(err)
-//     }
-//     client.SetMetricCollector(metricCollector)
+//
+//	config := centraldogma.DefaultMetricCollectorConfig("client_name")
+//	metricCollector, err := centraldogma.StatsdMetricCollector(config, "127.0.0.1:8125")
+//	if err != nil {
+//	    panic(err)
+//	}
+//	client.SetMetricCollector(metricCollector)
 func (c *Client) SetMetricCollector(m *metrics.Metrics) {
 	c.metricCollector = m
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.linecorp.com/centraldogma
 
-go 1.19
+go 1.18
 
 require (
 	github.com/armon/go-metrics v0.3.9

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module go.linecorp.com/centraldogma
 
+go 1.19
+
 require (
 	github.com/armon/go-metrics v0.3.9
 	github.com/prometheus/client_golang v1.11.0
@@ -7,4 +9,20 @@ require (
 	github.com/veqryn/h2c v1.0.0
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.26.0-rc.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -147,10 +147,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -326,12 +324,9 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -466,7 +461,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -324,9 +324,12 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/app/dogma/cli_cmds.go
+++ b/internal/app/dogma/cli_cmds.go
@@ -32,6 +32,11 @@ var revisionFlag = cli.StringFlag{
 	Usage: "Specifies the revision to operate",
 }
 
+var recursiveFlag = cli.BoolFlag{
+	Name:  "recursive",
+	Usage: "Specifies whether to download a whole directory",
+}
+
 var jsonPathFlag = cli.StringSliceFlag{
 	Name:  "jsonpath, j",
 	Usage: "Specifies the JSON path expressions to apply",
@@ -199,7 +204,7 @@ func CLICommands() []cli.Command {
 			Name:      "get",
 			Usage:     "Downloads a file in the path",
 			ArgsUsage: "<project_name>/<repository_name>/<path>",
-			Flags:     []cli.Flag{revisionFlag, jsonPathFlag},
+			Flags:     []cli.Flag{revisionFlag, jsonPathFlag, recursiveFlag},
 			Action: func(c *cli.Context) error {
 				command, err := newGetCommand(c, os.Stdout)
 				if err != nil {

--- a/internal/app/dogma/cmd.go
+++ b/internal/app/dogma/cmd.go
@@ -51,11 +51,12 @@ func getRemoteURL(remoteURL string) (string, error) {
 }
 
 type repositoryRequestInfo struct {
-	remoteURL string
-	projName  string
-	repoName  string
-	path      string
-	revision  string
+	remoteURL           string
+	projName            string
+	repoName            string
+	path                string
+	revision            string
+	isRecursiveDownload bool
 }
 
 // newRepositoryRequestInfo creates a repositoryRequestInfo.
@@ -85,6 +86,8 @@ func newRepositoryRequestInfo(c *cli.Context) (repositoryRequestInfo, error) {
 	if len(revision) != 0 {
 		repo.revision = revision
 	}
+
+	repo.isRecursiveDownload = c.Bool("recursive")
 	return repo, nil
 }
 

--- a/internal/app/dogma/cmd.go
+++ b/internal/app/dogma/cmd.go
@@ -133,6 +133,12 @@ func getRemoteFileEntry(c *cli.Context,
 		return nil, err
 	}
 
+	return getRemoteFileEntryWithDogmaClient(client,
+		projName, repoName, repoPath, revision, jsonPaths)
+}
+
+func getRemoteFileEntryWithDogmaClient(client *centraldogma.Client,
+	projName, repoName, repoPath, revision string, jsonPaths []string) (*centraldogma.Entry, error) {
 	query := createQuery(repoPath, jsonPaths)
 	entry, httpStatusCode, err := client.GetFile(context.Background(), projName, repoName, revision, query)
 	if err != nil {

--- a/internal/app/dogma/cmd_test.go
+++ b/internal/app/dogma/cmd_test.go
@@ -22,14 +22,27 @@ import (
 	"github.com/urfave/cli"
 )
 
-func newContext(flagArguments []string, connectURL, revision string) *cli.Context {
+func newParentContext(connectURL string) *cli.Context {
 	parentFlags := flag.NewFlagSet("test", 0)
 	parentFlags.String("connect", connectURL, "")
-	parent := cli.NewContext(nil, parentFlags, nil)
+	return cli.NewContext(nil, parentFlags, nil)
+}
+func newContext(flagArguments []string, connectURL, revision string) *cli.Context {
+	parent := newParentContext(connectURL)
 
 	flags := flag.FlagSet{}
 	flags.Parse(flagArguments)
 	flags.String("revision", revision, "")
+	return cli.NewContext(nil, &flags, parent)
+}
+
+func newGetCmdContext(flagArguments []string, connectURL, revision string, isRecursive bool) *cli.Context {
+	parent := newParentContext(connectURL)
+
+	flags := flag.FlagSet{}
+	flags.Parse(flagArguments)
+	flags.String("revision", revision, "")
+	flags.Bool("recursive", isRecursive, "")
 	return cli.NewContext(nil, &flags, parent)
 }
 

--- a/internal/app/dogma/edit_cmd_test.go
+++ b/internal/app/dogma/edit_cmd_test.go
@@ -51,7 +51,7 @@ func TestNewEditCommand(t *testing.T) {
 		case *editFileCommand:
 			got2 := editFileCommand(*comType)
 			if !reflect.DeepEqual(got2, test.want) {
-				t.Errorf("newEditCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+				t.Errorf("newEditCommand(%+v) = %+v, want: %+v", test.arguments, got2, test.want)
 			}
 		default:
 			t.Errorf("newEditCommand(%q) = %q, want: %q", test.arguments, got, test.want)

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -109,12 +109,11 @@ func (gd *getDirectoryCommand) executeWithDogmaClient(_ *cli.Context, client *ce
 	if err := os.MkdirAll(basename, defaultPermMode); err != nil {
 		return err
 	}
-	return gd.recurseDownload(context.Background(), basename, entry, client)
+	return gd.recurseDownload(context.Background(), client, basename, entry)
 }
 
-func (gd *getDirectoryCommand) recurseDownload(ctx context.Context,
-	basename string, rootEntry *centraldogma.Entry,
-	client *centraldogma.Client) error {
+func (gd *getDirectoryCommand) recurseDownload(ctx context.Context, client *centraldogma.Client,
+	basename string, rootEntry *centraldogma.Entry) error {
 	if rootEntry.Type != centraldogma.Directory {
 		return fmt.Errorf("%+q is not a directory, you might want to remove `--recursive` instead",
 			rootEntry.Path)

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -148,7 +148,11 @@ func (gd *getDirectoryCommand) recurseDownload(ctx context.Context, client *cent
 
 func (gd *getDirectoryCommand) downloadFile(client *centraldogma.Client, basename, path string) error {
 	repo := gd.repo
-	name := gd.constructFilename(basename, path)
+	name, err := gd.constructFilename(basename, path)
+	if err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(filepath.Dir(name), defaultPermMode); err != nil {
 		return err
 	}
@@ -188,10 +192,13 @@ func (gd *getDirectoryCommand) downloadFile(client *centraldogma.Client, basenam
 	return nil
 }
 
-func (gd *getDirectoryCommand) constructFilename(basename, path string) string {
+func (gd *getDirectoryCommand) constructFilename(basename, path string) (string, error) {
 	paths := strings.Split(path, "/")
+	if len(paths) < 3 {
+		return "", fmt.Errorf("invalid path: %q can't be processed", path)
+	}
 	cleanPath := filepath.Join(paths[2:]...)
-	return filepath.Join(basename, cleanPath)
+	return filepath.Join(basename, cleanPath), nil
 }
 
 func getRemoteEntry(c *cli.Context, repo *repositoryRequestInfo, path string, jsonPaths []string) (*centraldogma.Entry, error) {

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -135,7 +135,7 @@ func (gd *getDirectoryCommand) recurseDownload(ctx context.Context,
 	for _, entry := range entries {
 		switch entry.Type {
 		case centraldogma.Directory:
-			if err := gd.recurseDownload(ctx, basename, entry, client); err != nil {
+			if err := gd.recurseDownload(ctx, client, basename, entry); err != nil {
 				return err
 			}
 		default:

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -147,6 +147,7 @@ func (gd *getDirectoryCommand) recurseDownload(ctx context.Context,
 }
 
 func (gd *getDirectoryCommand) downloadFile(client *centraldogma.Client, basename, path string) error {
+	repo := gd.repo
 	name := gd.constructFilename(basename, path)
 	if err := os.MkdirAll(filepath.Dir(name), defaultPermMode); err != nil {
 		return err
@@ -157,7 +158,8 @@ func (gd *getDirectoryCommand) downloadFile(client *centraldogma.Client, basenam
 	}
 	defer fd.Close()
 
-	entry, err := getRemoteEntryWithDogmaClient(client, &gd.repo, path, gd.jsonPaths)
+	entry, err := getRemoteFileEntryWithDogmaClient(client,
+		repo.projName, repo.repoName, path, repo.revision, gd.jsonPaths)
 	if err != nil {
 		return err
 	}
@@ -188,16 +190,6 @@ func (gd *getDirectoryCommand) constructFilename(basename, path string) string {
 func getRemoteEntry(c *cli.Context, repo *repositoryRequestInfo, path string, jsonPaths []string) (*centraldogma.Entry, error) {
 	entry, err := getRemoteFileEntry(
 		c, repo.remoteURL, repo.projName, repo.repoName, path, repo.revision, jsonPaths)
-	if err != nil {
-		return nil, err
-	}
-
-	return entry, nil
-}
-
-func getRemoteEntryWithDogmaClient(client *centraldogma.Client, repo *repositoryRequestInfo, path string, jsonPaths []string) (*centraldogma.Entry, error) {
-	entry, err := getRemoteFileEntryWithDogmaClient(client,
-		repo.projName, repo.repoName, path, repo.revision, jsonPaths)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -171,8 +171,7 @@ func (gd *getDirectoryCommand) downloadFile(client *centraldogma.Client, basenam
 			return err
 		}
 	} else if entry.Type == centraldogma.Text {
-		_, err = fd.Write(entry.Content)
-		if err != nil {
+		if _, err = fd.Write(entry.Content); err != nil {
 			return err
 		}
 	}

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -109,10 +109,12 @@ func (gd *getDirectoryCommand) executeWithDogmaClient(c *cli.Context, client *ce
 	if err := os.MkdirAll(basename, defaultPermMode); err != nil {
 		return err
 	}
-	return gd.recurseDownload(context.Background(), c, basename, entry, client, &repo)
+	return gd.recurseDownload(context.Background(), basename, entry, client, &repo)
 }
 
-func (gd *getDirectoryCommand) recurseDownload(ctx context.Context, c *cli.Context, basename string, rootEntry *centraldogma.Entry, client *centraldogma.Client, repo *repositoryRequestInfo) error {
+func (gd *getDirectoryCommand) recurseDownload(ctx context.Context,
+	basename string, rootEntry *centraldogma.Entry,
+	client *centraldogma.Client, repo *repositoryRequestInfo) error {
 	if rootEntry.Type != centraldogma.Directory {
 		return fmt.Errorf("%+q is not a directory, you might want to remove `--recursive` instead",
 			rootEntry.Path)
@@ -132,7 +134,7 @@ func (gd *getDirectoryCommand) recurseDownload(ctx context.Context, c *cli.Conte
 	for _, entry := range entries {
 		switch entry.Type {
 		case centraldogma.Directory:
-			if err := gd.recurseDownload(ctx, c, basename, entry, client, repo); err != nil {
+			if err := gd.recurseDownload(ctx, basename, entry, client, repo); err != nil {
 				return err
 			}
 		default:

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -82,7 +82,6 @@ type getDirectoryCommand struct {
 	out           io.Writer
 	repo          repositoryRequestInfo
 	localFilePath string
-	jsonPaths     []string
 }
 
 func (gd *getDirectoryCommand) execute(c *cli.Context) error {
@@ -97,7 +96,7 @@ func (gd *getDirectoryCommand) execute(c *cli.Context) error {
 func (gd *getDirectoryCommand) executeWithDogmaClient(_ *cli.Context, client *centraldogma.Client) error {
 	repo := gd.repo
 	entry, err := getRemoteFileEntryWithDogmaClient(client,
-		repo.projName, repo.repoName, repo.path, repo.revision, gd.jsonPaths)
+		repo.projName, repo.repoName, repo.path, repo.revision, nil)
 	if err != nil {
 		return err
 	}
@@ -160,7 +159,7 @@ func (gd *getDirectoryCommand) downloadFile(client *centraldogma.Client, basenam
 	defer fd.Close()
 
 	entry, err := getRemoteFileEntryWithDogmaClient(client,
-		repo.projName, repo.repoName, path, repo.revision, gd.jsonPaths)
+		repo.projName, repo.repoName, path, repo.revision, nil)
 	if err != nil {
 		return err
 	}
@@ -255,7 +254,6 @@ func newGetCommand(c *cli.Context, out io.Writer) (Command, error) {
 			out:           out,
 			repo:          repo,
 			localFilePath: localFilePath,
-			jsonPaths:     c.StringSlice("jsonpath"),
 		}, nil
 	}
 

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -15,15 +15,22 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"io"
-	"os"
-	"path"
-	"regexp"
-	"strconv"
-
 	"github.com/urfave/cli"
 	"go.linecorp.com/centraldogma"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultPermMode = 0755
 )
 
 // A getFileCommand fetches the content of the file in the specified path matched by the
@@ -37,10 +44,14 @@ type getFileCommand struct {
 
 func (gf *getFileCommand) execute(c *cli.Context) error {
 	repo := gf.repo
-	entry, err := getRemoteFileEntry(
-		c, repo.remoteURL, repo.projName, repo.repoName, repo.path, repo.revision, gf.jsonPaths)
+
+	entry, err := getRemoteEntry(c, &repo, repo.path, gf.jsonPaths)
 	if err != nil {
 		return err
+	}
+
+	if entry.Type == centraldogma.Directory && !repo.isRecursiveDownload {
+		return fmt.Errorf("%+q is a directory, you might want to use `--recursive` instead", repo.path)
 	}
 
 	filePath := creatableFilePath(gf.localFilePath, 1)
@@ -64,6 +75,118 @@ func (gf *getFileCommand) execute(c *cli.Context) error {
 
 	fmt.Fprintf(gf.out, "Downloaded: %s\n", path.Base(filePath))
 	return nil
+}
+
+type getDirectoryCommand struct {
+	out io.Writer
+	repo repositoryRequestInfo
+	localFilePath string
+	jsonPaths []string
+}
+
+func (gd *getDirectoryCommand) execute(c *cli.Context) error {
+	repo := gd.repo
+	entry, err := getRemoteFileEntry(
+		c, repo.remoteURL, repo.projName, repo.repoName, repo.path, repo.revision, gd.jsonPaths)
+	if err != nil {
+		return err
+	}
+
+	if entry.Type != centraldogma.Directory && repo.isRecursiveDownload {
+		return fmt.Errorf("%+q is not a directory, you might want to remove `--recursive` instead", repo.path)
+	}
+
+	client, err := newDogmaClient(c, repo.remoteURL)
+	if err != nil {
+		return err
+	}
+
+	basename := creatableFilePath(gd.localFilePath, 1)
+	if err := os.MkdirAll(basename, defaultPermMode) ; err != nil {
+		return err
+	}
+	return gd.recurseDownload(context.Background(), c, basename, entry, client, &repo)
+}
+
+func (gd *getDirectoryCommand) recurseDownload(ctx context.Context, c *cli.Context, basename string, rootEntry *centraldogma.Entry, client *centraldogma.Client, repo *repositoryRequestInfo) error {
+	if rootEntry.Type != centraldogma.Directory {
+		return fmt.Errorf("%+q is not a directory, you might want to remove `--recursive` instead",
+			rootEntry.Path)
+	}
+
+	path := rootEntry.Path
+	entries, httpStatusCode, err := client.ListFiles(ctx, repo.projName, repo.repoName, repo.revision, path)
+	if err != nil {
+		return err
+	}
+
+	if httpStatusCode != http.StatusOK {
+		return fmt.Errorf("failed to get the list of files in the /%s/%s%s revision: %q (status: %d)",
+			repo.projName, repo.repoName, path, repo.revision, httpStatusCode)
+	}
+
+	for _, entry := range entries {
+		switch entry.Type {
+		case centraldogma.Directory:
+			if err := gd.recurseDownload(ctx, c, basename, entry, client, repo) ; err != nil {
+				return err
+			}
+		default:
+			if err := gd.downloadFile(c, basename, entry.Path) ; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (gd *getDirectoryCommand) downloadFile(c *cli.Context, basename, path string) error {
+	name := gd.constructFilename(basename, path)
+	if err := os.MkdirAll(filepath.Dir(name), defaultPermMode) ; err != nil {
+		return err
+	}
+	fd, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	entry, err := getRemoteEntry(c, &gd.repo, path, gd.jsonPaths)
+	if err != nil {
+		return err
+	}
+
+	if entry.Type == centraldogma.JSON {
+		b := safeMarshalIndent(entry.Content)
+		if _, err = fd.Write(b); err != nil {
+			return err
+		}
+	} else if entry.Type == centraldogma.Text {
+		_, err = fd.Write(entry.Content)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(gd.out, "Downloaded: %s\n", name)
+
+	return nil
+}
+
+func (gd *getDirectoryCommand) constructFilename(basename, path string) string {
+	paths := strings.Split(path, "/")
+	cleanPath := strings.Join(paths[2:], "/")
+	return basename+"/"+cleanPath
+}
+
+func getRemoteEntry(c *cli.Context, repo *repositoryRequestInfo, path string, jsonPaths []string) (*centraldogma.Entry, error) {
+	entry, err := getRemoteFileEntry(
+		c, repo.remoteURL, repo.projName, repo.repoName, path, repo.revision, jsonPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
 }
 
 // A catFileCommand shows the content of the file in the specified path matched by the
@@ -117,6 +240,15 @@ func newGetCommand(c *cli.Context, out io.Writer) (Command, error) {
 	localFilePath := path.Base(repo.path)
 	if len(c.Args()) == 2 && len(c.Args().Get(1)) != 0 {
 		localFilePath = c.Args().Get(1)
+	}
+
+	if repo.isRecursiveDownload {
+		return &getDirectoryCommand{
+			out: out,
+			repo: repo,
+			localFilePath: localFilePath,
+			jsonPaths: c.StringSlice("jsonpath"),
+		}, nil
 	}
 
 	return &getFileCommand{out: out, repo: repo, localFilePath: localFilePath, jsonPaths: c.StringSlice("jsonpath")}, nil

--- a/internal/app/dogma/get_cmd.go
+++ b/internal/app/dogma/get_cmd.go
@@ -17,8 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/urfave/cli"
-	"go.linecorp.com/centraldogma"
 	"io"
 	"net/http"
 	"os"
@@ -27,6 +25,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/urfave/cli"
+	"go.linecorp.com/centraldogma"
 )
 
 const (

--- a/internal/app/dogma/get_cmd_test.go
+++ b/internal/app/dogma/get_cmd_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"go.linecorp.com/centraldogma"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +27,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"go.linecorp.com/centraldogma"
 )
 
 func TestNewGetCommand(t *testing.T) {

--- a/internal/app/dogma/get_cmd_test.go
+++ b/internal/app/dogma/get_cmd_test.go
@@ -135,7 +135,6 @@ func TestGetRecursive(t *testing.T) {
 	rand.Read(b)
 	localFilePath := "/tmp/" + hex.EncodeToString(b)
 	defer os.RemoveAll(localFilePath)
-	defer os.RemoveAll(localFilePath + ".1")
 
 	remoteURL := server.URL
 	c := newGetCmdContext([]string{"abcd/repo1/x", localFilePath}, remoteURL, "", true)

--- a/internal/app/dogma/go.mod
+++ b/internal/app/dogma/go.mod
@@ -1,6 +1,6 @@
 module go.linecorp.com/centraldogma/internal/app/dogma
 
-go 1.19
+go 1.18
 
 require (
 	github.com/urfave/cli v1.22.5

--- a/internal/app/dogma/go.mod
+++ b/internal/app/dogma/go.mod
@@ -1,6 +1,31 @@
 module go.linecorp.com/centraldogma/internal/app/dogma
 
+go 1.19
+
 require (
 	github.com/urfave/cli v1.22.5
 	go.linecorp.com/centraldogma v0.0.0-20210727074804-df3201eea9dc
+)
+
+require (
+	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_golang v1.1.0 // indirect
+	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
+	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/procfs v0.0.3 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 )

--- a/internal/app/dogma/ls_cmds_test.go
+++ b/internal/app/dogma/ls_cmds_test.go
@@ -112,7 +112,7 @@ func TestNewLSCommand(t *testing.T) {
 		case *lsPathCommand:
 			got2 := lsPathCommand(*comType)
 			if !reflect.DeepEqual(got2, test.want) {
-				t.Errorf("newAddCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+				t.Errorf("newAddCommand(%+v) = %+v, want: %+v", test.arguments, got2, test.want)
 			}
 		default:
 			t.Errorf("newLSCommand(%q) = %q, want: %q", test.arguments, got, test.want)

--- a/internal/app/dogma/new_cmds_test.go
+++ b/internal/app/dogma/new_cmds_test.go
@@ -178,7 +178,7 @@ func TestNewAddCommand(t *testing.T) {
 		case *putFileCommand:
 			got2 := putFileCommand(*comType)
 			if !reflect.DeepEqual(got2, test.want) {
-				t.Errorf("newPutCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+				t.Errorf("newPutCommand(%+v) = %+v, want: %+v", test.arguments, got2, test.want)
 			}
 		default:
 			t.Errorf("newPutCommand(%q) = %q, want: %q", test.arguments, got, test.want)

--- a/internal/app/dogma/normalize_cmd_test.go
+++ b/internal/app/dogma/normalize_cmd_test.go
@@ -61,7 +61,7 @@ func TestNewNormalizeCommand(t *testing.T) {
 				t.Errorf("newNormalizeCommand(%+v) = %+v, want: %+v", test.arguments, got2, test.want)
 			}
 		default:
-			t.Errorf("newNormalizeCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+			t.Errorf("newNormalizeCommand(%+v) = %+v, want: %+v", test.arguments, got, test.want)
 		}
 	}
 }

--- a/internal/app/dogma/normalize_cmd_test.go
+++ b/internal/app/dogma/normalize_cmd_test.go
@@ -58,7 +58,7 @@ func TestNewNormalizeCommand(t *testing.T) {
 		case *normalizeRevisionCommand:
 			got2 := normalizeRevisionCommand(*comType)
 			if !reflect.DeepEqual(got2, test.want) {
-				t.Errorf("newNormalizeCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+				t.Errorf("newNormalizeCommand(%+v) = %+v, want: %+v", test.arguments, got2, test.want)
 			}
 		default:
 			t.Errorf("newNormalizeCommand(%q) = %q, want: %q", test.arguments, got, test.want)


### PR DESCRIPTION
### Motivation

Support #48 

### Modifications

- add `--recursive` flags on `dogma get` command, only works if the given path is a directory
- add recursive download tests

### Result

<details>
<summary>Recursive on File</summary>

```shell
$ ./dogma --connect http://localhost:36462 get abcd/repo1/x/foo.json --recursive
"/x/foo.json" is not a directory, you might want to remove `--recursive` instead
```

</details>

<details>
<summary>Not Recursive on Directory</summary>

```shell
$ ./dogma --connect http://localhost:36462 get abcd/repo1/x
"/x" is a directory, you might want to use `--recursive` instead
```

</details>

<details>
<summary>Recursive on Directory</summary>

```shell
$ ./dogma --connect http://localhost:36462 get abcd/repo1/x --recursive
Downloaded: x/bar.json
Downloaded: x/foo.json
Downloaded: x/y/foo.json
Downloaded: x/y/z/bar.json
```

</details>

<details>
<summary>Recursive on Existing Directory</summary>

```shell
$ ./dogma --connect http://localhost:36462 get abcd/repo1/x --recursive
Downloaded: x.1/bar.json
Downloaded: x.1/foo.json
Downloaded: x.1/y/foo.json
Downloaded: x.1/y/z/bar.json
```
</details>