### PR TITLE
Add a build script to create cli binaries for different architectures and operating systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Build output
-internal/app/dogma/dogma
+internal/app/dogma/build
 
 # GoLand
 .idea

--- a/internal/app/dogma/build-cli.sh
+++ b/internal/app/dogma/build-cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_name=dogma
+platforms=("windows/amd64" "linux/amd64" "darwin/amd64" "darwin/arm64")
+
+for platform in "${platforms[@]}"
+do
+	platform_split=(${platform//\// })
+	GOOS=${platform_split[0]}
+	GOARCH=${platform_split[1]}
+	output_name=$app_name'.'$GOOS'-'$GOARCH
+	if [ $GOOS = "windows" ]; then
+		output_name+='.exe'
+	fi	
+
+	env GOOS=$GOOS GOARCH=$GOARCH go build -o build/$output_name
+	if [ $? -ne 0 ]; then
+   		echo 'An error has occurred! Aborting the script execution...'
+		exit 1
+	fi
+done

--- a/internal/app/dogma/build-cli.sh
+++ b/internal/app/dogma/build-cli.sh
@@ -6,17 +6,17 @@ platforms=("windows/amd64" "linux/amd64" "darwin/amd64" "darwin/arm64")
 
 for platform in "${platforms[@]}"
 do
-	platform_split=(${platform//\// })
-	GOOS=${platform_split[0]}
-	GOARCH=${platform_split[1]}
-	output_name=$app_name'.'$GOOS'-'$GOARCH
-	if [ $GOOS = "windows" ]; then
-		output_name+='.exe'
-	fi	
+    platform_split=(${platform//\// })
+    GOOS=${platform_split[0]}
+    GOARCH=${platform_split[1]}
+    output_name=$app_name'.'$GOOS'-'$GOARCH
+    if [ $GOOS = "windows" ]; then
+        output_name+='.exe'
+    fi
 
-	env GOOS=$GOOS GOARCH=$GOARCH go build -o build/$output_name
-	if [ $? -ne 0 ]; then
-   		echo 'An error has occurred! Aborting the script execution...'
-		exit 1
-	fi
+    env GOOS=$GOOS GOARCH=$GOARCH go build -o build/$output_name
+    if [ $? -ne 0 ]; then
+        echo 'An error has occurred! Aborting the script execution...'
+        exit 1
+    fi
 done


### PR DESCRIPTION
We don't build and publish Central Dogma binaries on a regular basis yet. A build script and manual uploading would be sufficient at the moment.

This will resolve the Apple silicon support in Central Dogma cli https://github.com/line/centraldogma/issues/779