### PR TITLE
Follow the semver naming rule of Go modules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 
 # Coverage output
 coverage.txt
+
+internal/app/dogma/build


### PR DESCRIPTION
Motivation:

> semantic version strings must begin with a leading "v", as in "v1.0.0".
https://pkg.go.dev/golang.org/x/mod/semver

Modifications:

- Release new versions when a tag starts with `v`.

Result:

Semantic versions are published to https://pkg.go.dev/go.linecorp.com/centraldogma