### PR TITLE
Support AppIdentity API

### DIFF
--- a/app_identity_service.go
+++ b/app_identity_service.go
@@ -175,26 +175,6 @@ func (a *appIdentityService) remove(ctx context.Context, appID string) (*AppIden
 	return appIdentity, httpStatusCode, nil
 }
 
-func (a *appIdentityService) purge(ctx context.Context, appID string) (*AppIdentity, int, error) {
-	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities, appID, actionRemoved))
-	if err != nil {
-		return nil, UnknownHttpStatusCode, err
-	}
-
-	req, err := a.client.newRequest(http.MethodDelete, u, nil)
-	if err != nil {
-		return nil, UnknownHttpStatusCode, err
-	}
-
-	appIdentity := new(AppIdentity)
-	httpStatusCode, err := a.client.do(ctx, req, appIdentity, false)
-	if err != nil {
-		return nil, httpStatusCode, err
-	}
-
-	return appIdentity, httpStatusCode, nil
-}
-
 func (a *appIdentityService) updateStatus(
 	ctx context.Context, appID string, status AppIdentityStatus) (*AppIdentity, int, error) {
 	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities, appID))

--- a/app_identity_service.go
+++ b/app_identity_service.go
@@ -2,6 +2,8 @@ package centraldogma
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -24,6 +26,31 @@ type ProjectRole string
 const (
 	ProjectRoleOwner  ProjectRole = "OWNER"
 	ProjectRoleMember ProjectRole = "MEMBER"
+)
+
+// RepositoryRole represents a role of an app identity in a repository.
+type RepositoryRole string
+
+const (
+	RepositoryRoleAdmin RepositoryRole = "ADMIN"
+	RepositoryRoleWrite RepositoryRole = "WRITE"
+	RepositoryRoleRead  RepositoryRole = "READ"
+)
+
+// AppIdentityStatus represents activation status of an app identity.
+type AppIdentityStatus string
+
+const (
+	AppIdentityStatusActive   AppIdentityStatus = "active"
+	AppIdentityStatusInactive AppIdentityStatus = "inactive"
+)
+
+// AppIdentityLevel represents permission level of an app identity.
+type AppIdentityLevel string
+
+const (
+	AppIdentityLevelUser        AppIdentityLevel = "USER"
+	AppIdentityLevelSystemAdmin AppIdentityLevel = "SYSTEMADMIN"
 )
 
 // UserAndTimestamp represents who performed an action and when.
@@ -52,6 +79,29 @@ type CreateAppIdentityRequest struct {
 	IsSystemAdmin bool
 	Secret        string
 	CertificateID string
+}
+
+type appIdentityRevision int
+
+func (r *appIdentityRevision) UnmarshalJSON(data []byte) error {
+	// Some endpoints return a plain number (e.g. 49) while others may return {"revision":49}.
+	var value int
+	if err := json.Unmarshal(data, &value); err == nil {
+		*r = appIdentityRevision(value)
+		return nil
+	}
+
+	var payload struct {
+		Revision *int `json:"revision"`
+	}
+	if err := json.Unmarshal(data, &payload); err == nil {
+		if payload.Revision != nil {
+			*r = appIdentityRevision(*payload.Revision)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unsupported revision payload: %s", string(data))
 }
 
 func (a *appIdentityService) create(ctx context.Context, request *CreateAppIdentityRequest) (*AppIdentity, int, error) {
@@ -86,6 +136,115 @@ func (a *appIdentityService) create(ctx context.Context, request *CreateAppIdent
 	return appIdentity, httpStatusCode, nil
 }
 
+func (a *appIdentityService) list(ctx context.Context) ([]*AppIdentity, int, error) {
+	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities))
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	req, err := a.client.newRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	var appIDs []*AppIdentity
+	httpStatusCode, err := a.client.do(ctx, req, &appIDs, false)
+	if err != nil {
+		return nil, httpStatusCode, err
+	}
+	return appIDs, httpStatusCode, nil
+}
+
+func (a *appIdentityService) remove(ctx context.Context, appID string) (*AppIdentity, int, error) {
+	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities, appID))
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	req, err := a.client.newRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	appIdentity := new(AppIdentity)
+	httpStatusCode, err := a.client.do(ctx, req, appIdentity, false)
+	if err != nil {
+		return nil, httpStatusCode, err
+	}
+
+	return appIdentity, httpStatusCode, nil
+}
+
+func (a *appIdentityService) purge(ctx context.Context, appID string) (*AppIdentity, int, error) {
+	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities, appID, actionRemoved))
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	req, err := a.client.newRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	appIdentity := new(AppIdentity)
+	httpStatusCode, err := a.client.do(ctx, req, appIdentity, false)
+	if err != nil {
+		return nil, httpStatusCode, err
+	}
+
+	return appIdentity, httpStatusCode, nil
+}
+
+func (a *appIdentityService) updateStatus(
+	ctx context.Context, appID string, status AppIdentityStatus) (*AppIdentity, int, error) {
+	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities, appID))
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	body := map[string]string{"status": string(status)}
+	req, err := a.client.newRequest(http.MethodPatch, u, body)
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	// This endpoint accepts application/json, not JSON patch.
+	req.Header.Set("Content-Type", "application/json")
+
+	appIdentity := new(AppIdentity)
+	httpStatusCode, err := a.client.do(ctx, req, appIdentity, false)
+	if err != nil {
+		return nil, httpStatusCode, err
+	}
+
+	return appIdentity, httpStatusCode, nil
+}
+
+func (a *appIdentityService) updateLevel(
+	ctx context.Context, appID string, level AppIdentityLevel) (*AppIdentity, int, error) {
+	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities, appID, "level"))
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	body := map[string]string{"level": string(level)}
+	req, err := a.client.newRequest(http.MethodPatch, u, body)
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	// This endpoint accepts application/json, not JSON patch.
+	req.Header.Set("Content-Type", "application/json")
+
+	appIdentity := new(AppIdentity)
+	httpStatusCode, err := a.client.do(ctx, req, appIdentity, false)
+	if err != nil {
+		return nil, httpStatusCode, err
+	}
+
+	return appIdentity, httpStatusCode, nil
+}
+
 func (a *appIdentityService) addToProject(
 	ctx context.Context, projectName, appID string, role ProjectRole) (int, int, error) {
 	u, err := url.Parse(path.Join(
@@ -103,11 +262,114 @@ func (a *appIdentityService) addToProject(
 		return -1, UnknownHttpStatusCode, err
 	}
 
-	revision := new(rev)
-	httpStatusCode, err := a.client.do(ctx, req, revision, false)
+	var revision appIdentityRevision
+	httpStatusCode, err := a.client.do(ctx, req, &revision, false)
 	if err != nil {
 		return -1, httpStatusCode, err
 	}
 
-	return revision.Rev, httpStatusCode, nil
+	return int(revision), httpStatusCode, nil
+}
+
+func (a *appIdentityService) updateProjectRole(
+	ctx context.Context, projectName, appID string, role ProjectRole) (int, int, error) {
+	u, err := url.Parse(path.Join(
+		defaultPathPrefix,
+		metadata, projectName,
+		appIdentities, appID,
+	))
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	body := `[{"op":"replace", "path":"/role", "value":"` + string(role) + `"}]`
+	req, err := a.client.newRequest(http.MethodPatch, u, body)
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	var revision appIdentityRevision
+	httpStatusCode, err := a.client.do(ctx, req, &revision, false)
+	if err != nil {
+		return -1, httpStatusCode, err
+	}
+
+	return int(revision), httpStatusCode, nil
+}
+
+func (a *appIdentityService) removeFromProject(ctx context.Context, projectName, appID string) (int, int, error) {
+	u, err := url.Parse(path.Join(
+		defaultPathPrefix,
+		metadata, projectName,
+		appIdentities, appID,
+	))
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	req, err := a.client.newRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	var revision appIdentityRevision
+	httpStatusCode, err := a.client.do(ctx, req, &revision, false)
+	if err != nil {
+		return -1, httpStatusCode, err
+	}
+
+	return int(revision), httpStatusCode, nil
+}
+
+func (a *appIdentityService) addToRepository(
+	ctx context.Context, projectName, repoName, appID string, role RepositoryRole) (int, int, error) {
+	u, err := url.Parse(path.Join(
+		defaultPathPrefix,
+		metadata, projectName,
+		repos, repoName,
+		"roles", appIdentities,
+	))
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	body := map[string]string{"id": appID, "role": string(role)}
+	req, err := a.client.newRequest(http.MethodPost, u, body)
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	var revision appIdentityRevision
+	httpStatusCode, err := a.client.do(ctx, req, &revision, false)
+	if err != nil {
+		return -1, httpStatusCode, err
+	}
+
+	return int(revision), httpStatusCode, nil
+}
+
+func (a *appIdentityService) removeFromRepository(
+	ctx context.Context, projectName, repoName, appID string) (int, int, error) {
+	u, err := url.Parse(path.Join(
+		defaultPathPrefix,
+		metadata, projectName,
+		repos, repoName,
+		"roles", appIdentities, appID,
+	))
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	req, err := a.client.newRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	var revision appIdentityRevision
+	httpStatusCode, err := a.client.do(ctx, req, &revision, false)
+	if err != nil {
+		return -1, httpStatusCode, err
+	}
+
+	return int(revision), httpStatusCode, nil
 }

--- a/app_identity_service.go
+++ b/app_identity_service.go
@@ -1,0 +1,113 @@
+package centraldogma
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+)
+
+type appIdentityService service
+
+// AppIdentityType represents a type of app identity.
+type AppIdentityType string
+
+const (
+	AppIdentityTypeToken       AppIdentityType = "TOKEN"
+	AppIdentityTypeCertificate AppIdentityType = "CERTIFICATE"
+)
+
+// ProjectRole represents a role of an app identity in a project.
+type ProjectRole string
+
+const (
+	ProjectRoleOwner  ProjectRole = "OWNER"
+	ProjectRoleMember ProjectRole = "MEMBER"
+)
+
+// UserAndTimestamp represents who performed an action and when.
+type UserAndTimestamp struct {
+	User      string `json:"user,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// AppIdentity represents an app identity in the Central Dogma server.
+type AppIdentity struct {
+	AppID            string            `json:"appId"`
+	Type             AppIdentityType   `json:"type,omitempty"`
+	Secret           string            `json:"secret,omitempty"`
+	CertificateID    string            `json:"certificateId,omitempty"`
+	SystemAdmin      bool              `json:"systemAdmin,omitempty"`
+	AllowGuestAccess bool              `json:"allowGuestAccess,omitempty"`
+	Creation         *UserAndTimestamp `json:"creation,omitempty"`
+	Deactivation     *UserAndTimestamp `json:"deactivation,omitempty"`
+	Deletion         *UserAndTimestamp `json:"deletion,omitempty"`
+}
+
+// CreateAppIdentityRequest is used for creating an app identity.
+type CreateAppIdentityRequest struct {
+	AppID         string
+	Type          AppIdentityType
+	IsSystemAdmin bool
+	Secret        string
+	CertificateID string
+}
+
+func (a *appIdentityService) create(ctx context.Context, request *CreateAppIdentityRequest) (*AppIdentity, int, error) {
+	u, err := url.Parse(path.Join(defaultPathPrefix, appIdentities))
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	q := u.Query()
+	q.Set("appId", request.AppID)
+	q.Set("type", string(request.Type))
+	q.Set("isSystemAdmin", strconv.FormatBool(request.IsSystemAdmin))
+	if request.Secret != "" {
+		q.Set("secret", request.Secret)
+	}
+	if request.CertificateID != "" {
+		q.Set("certificateId", request.CertificateID)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := a.client.newRequest(http.MethodPost, u, nil)
+	if err != nil {
+		return nil, UnknownHttpStatusCode, err
+	}
+
+	appIdentity := new(AppIdentity)
+	httpStatusCode, err := a.client.do(ctx, req, appIdentity, false)
+	if err != nil {
+		return nil, httpStatusCode, err
+	}
+
+	return appIdentity, httpStatusCode, nil
+}
+
+func (a *appIdentityService) addToProject(
+	ctx context.Context, projectName, appID string, role ProjectRole) (int, int, error) {
+	u, err := url.Parse(path.Join(
+		defaultPathPrefix,
+		metadata, projectName,
+		appIdentities,
+	))
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	body := map[string]string{"id": appID, "role": string(role)}
+	req, err := a.client.newRequest(http.MethodPost, u, body)
+	if err != nil {
+		return -1, UnknownHttpStatusCode, err
+	}
+
+	revision := new(rev)
+	httpStatusCode, err := a.client.do(ctx, req, revision, false)
+	if err != nil {
+		return -1, httpStatusCode, err
+	}
+
+	return revision.Rev, httpStatusCode, nil
+}

--- a/app_identity_service_test.go
+++ b/app_identity_service_test.go
@@ -1,0 +1,93 @@
+package centraldogma
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestCreateAppIdentity(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	request := &CreateAppIdentityRequest{
+		AppID:         "my-app",
+		Type:          AppIdentityTypeToken,
+		IsSystemAdmin: false,
+	}
+
+	mux.HandleFunc("/api/v1/appIdentities", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testAuthorization(t, r)
+		testURLQuery(t, r, "appId", "my-app")
+		testURLQuery(t, r, "type", "TOKEN")
+		testURLQuery(t, r, "isSystemAdmin", "false")
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Location", "/api/v1/appIdentities/my-app")
+		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN","secret":"appToken-secret","systemAdmin":false}`)
+	})
+
+	appIdentity, httpStatusCode, _ := c.CreateAppIdentity(context.Background(), request)
+	testStatusCode(t, httpStatusCode, 201)
+
+	want := &AppIdentity{AppID: "my-app", Type: AppIdentityTypeToken, Secret: "appToken-secret"}
+	if !reflect.DeepEqual(appIdentity, want) {
+		t.Errorf("CreateAppIdentity returned %+v, want %+v", appIdentity, want)
+	}
+}
+
+func TestCreateCertificateAppIdentity(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	request := &CreateAppIdentityRequest{
+		AppID:         "mtls-app",
+		Type:          AppIdentityTypeCertificate,
+		IsSystemAdmin: true,
+		CertificateID: "cert-1",
+	}
+
+	mux.HandleFunc("/api/v1/appIdentities", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testURLQuery(t, r, "appId", "mtls-app")
+		testURLQuery(t, r, "type", "CERTIFICATE")
+		testURLQuery(t, r, "isSystemAdmin", "true")
+		testURLQuery(t, r, "certificateId", "cert-1")
+		fmt.Fprint(w, `{"appId":"mtls-app","type":"CERTIFICATE","certificateId":"cert-1","systemAdmin":true}`)
+	})
+
+	appIdentity, _, _ := c.CreateAppIdentity(context.Background(), request)
+	want := &AppIdentity{AppID: "mtls-app", Type: AppIdentityTypeCertificate, CertificateID: "cert-1", SystemAdmin: true}
+	if !reflect.DeepEqual(appIdentity, want) {
+		t.Errorf("CreateAppIdentity returned %+v, want %+v", appIdentity, want)
+	}
+}
+
+func TestAddAppIdentityToProject(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	input := map[string]string{"id": "my-app", "role": "MEMBER"}
+
+	mux.HandleFunc("/api/v1/metadata/foo/appIdentities", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testAuthorization(t, r)
+
+		body := map[string]string{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if !reflect.DeepEqual(body, input) {
+			t.Errorf("Request body = %+v, want %+v", body, input)
+		}
+
+		fmt.Fprint(w, `{"revision":7}`)
+	})
+
+	revision, httpStatusCode, _ := c.AddAppIdentityToProject(context.Background(), "foo", "my-app", ProjectRoleMember)
+	testStatusCode(t, httpStatusCode, 200)
+	if revision != 7 {
+		t.Errorf("AddAppIdentityToProject returned %v, want %v", revision, 7)
+	}
+}

--- a/app_identity_service_test.go
+++ b/app_identity_service_test.go
@@ -177,32 +177,6 @@ func TestRepositoryRoleAPIs(t *testing.T) {
 	}
 }
 
-func TestRemoveAndPurgeAppIdentity(t *testing.T) {
-	c, mux, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/api/v1/appIdentities/my-app", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodDelete)
-		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN"}`)
-	})
-	mux.HandleFunc("/api/v1/appIdentities/my-app/removed", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodDelete)
-		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN"}`)
-	})
-
-	appID, httpStatusCode, _ := c.RemoveAppIdentity(context.Background(), "my-app")
-	testStatusCode(t, httpStatusCode, 200)
-	if appID.AppID != "my-app" {
-		t.Errorf("RemoveAppIdentity returned %+v, want appId my-app", appID)
-	}
-
-	appID, httpStatusCode, _ = c.PurgeAppIdentity(context.Background(), "my-app")
-	testStatusCode(t, httpStatusCode, 200)
-	if appID.AppID != "my-app" {
-		t.Errorf("PurgeAppIdentity returned %+v, want appId my-app", appID)
-	}
-}
-
 func TestAppIdentityRevisionUnmarshalJSON(t *testing.T) {
 	var fromNumber appIdentityRevision
 	if err := json.Unmarshal([]byte(`49`), &fromNumber); err != nil {

--- a/app_identity_service_test.go
+++ b/app_identity_service_test.go
@@ -39,55 +39,189 @@ func TestCreateAppIdentity(t *testing.T) {
 	}
 }
 
-func TestCreateCertificateAppIdentity(t *testing.T) {
+func TestListAppIdentities(t *testing.T) {
 	c, mux, teardown := setup()
 	defer teardown()
 
-	request := &CreateAppIdentityRequest{
-		AppID:         "mtls-app",
-		Type:          AppIdentityTypeCertificate,
-		IsSystemAdmin: true,
-		CertificateID: "cert-1",
-	}
-
 	mux.HandleFunc("/api/v1/appIdentities", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodPost)
-		testURLQuery(t, r, "appId", "mtls-app")
-		testURLQuery(t, r, "type", "CERTIFICATE")
-		testURLQuery(t, r, "isSystemAdmin", "true")
-		testURLQuery(t, r, "certificateId", "cert-1")
-		fmt.Fprint(w, `{"appId":"mtls-app","type":"CERTIFICATE","certificateId":"cert-1","systemAdmin":true}`)
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `[{"appId":"app1","type":"TOKEN"},{"appId":"app2","type":"CERTIFICATE","certificateId":"cert-2"}]`)
 	})
 
-	appIdentity, _, _ := c.CreateAppIdentity(context.Background(), request)
-	want := &AppIdentity{AppID: "mtls-app", Type: AppIdentityTypeCertificate, CertificateID: "cert-1", SystemAdmin: true}
-	if !reflect.DeepEqual(appIdentity, want) {
-		t.Errorf("CreateAppIdentity returned %+v, want %+v", appIdentity, want)
+	appIDs, httpStatusCode, _ := c.ListAppIdentities(context.Background())
+	testStatusCode(t, httpStatusCode, 200)
+
+	want := []*AppIdentity{
+		{AppID: "app1", Type: AppIdentityTypeToken},
+		{AppID: "app2", Type: AppIdentityTypeCertificate, CertificateID: "cert-2"},
+	}
+	if !reflect.DeepEqual(appIDs, want) {
+		t.Errorf("ListAppIdentities returned %+v, want %+v", appIDs, want)
 	}
 }
 
-func TestAddAppIdentityToProject(t *testing.T) {
+func TestUpdateAppIdentityStatus(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v1/appIdentities/my-app", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"status":"inactive"}`+"\n")
+		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN","deactivation":{"user":"u","timestamp":"2026-01-01T00:00:00Z"}}`)
+	})
+
+	appID, httpStatusCode, _ := c.UpdateAppIdentityStatus(context.Background(), "my-app", AppIdentityStatusInactive)
+	testStatusCode(t, httpStatusCode, 200)
+
+	if appID.AppID != "my-app" {
+		t.Errorf("UpdateAppIdentityStatus returned %+v, want appId my-app", appID)
+	}
+}
+
+func TestUpdateAppIdentityLevel(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v1/appIdentities/my-app/level", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		testHeader(t, r, "Content-Type", "application/json")
+		testBody(t, r, `{"level":"SYSTEMADMIN"}`+"\n")
+		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN","systemAdmin":true}`)
+	})
+
+	appID, httpStatusCode, _ := c.UpdateAppIdentityLevel(context.Background(), "my-app", AppIdentityLevelSystemAdmin)
+	testStatusCode(t, httpStatusCode, 200)
+
+	want := &AppIdentity{AppID: "my-app", Type: AppIdentityTypeToken, SystemAdmin: true}
+	if !reflect.DeepEqual(appID, want) {
+		t.Errorf("UpdateAppIdentityLevel returned %+v, want %+v", appID, want)
+	}
+}
+
+func TestProjectRoleAPIs(t *testing.T) {
 	c, mux, teardown := setup()
 	defer teardown()
 
 	input := map[string]string{"id": "my-app", "role": "MEMBER"}
-
 	mux.HandleFunc("/api/v1/metadata/foo/appIdentities", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
-		testAuthorization(t, r)
-
 		body := map[string]string{}
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		if !reflect.DeepEqual(body, input) {
 			t.Errorf("Request body = %+v, want %+v", body, input)
 		}
-
-		fmt.Fprint(w, `{"revision":7}`)
+		fmt.Fprint(w, `49`)
+	})
+	mux.HandleFunc("/api/v1/metadata/foo/appIdentities/my-app", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPatch:
+			testHeader(t, r, "Content-Type", "application/json-patch+json")
+			testBody(t, r, `[{"op":"replace", "path":"/role", "value":"OWNER"}]`)
+			fmt.Fprint(w, `50`)
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
 	})
 
 	revision, httpStatusCode, _ := c.AddAppIdentityToProject(context.Background(), "foo", "my-app", ProjectRoleMember)
 	testStatusCode(t, httpStatusCode, 200)
-	if revision != 7 {
-		t.Errorf("AddAppIdentityToProject returned %v, want %v", revision, 7)
+	if revision != 49 {
+		t.Errorf("AddAppIdentityToProject returned %v, want %v", revision, 49)
+	}
+
+	revision, httpStatusCode, _ = c.UpdateAppIdentityProjectRole(context.Background(), "foo", "my-app", ProjectRoleOwner)
+	testStatusCode(t, httpStatusCode, 200)
+	if revision != 50 {
+		t.Errorf("UpdateAppIdentityProjectRole returned %v, want %v", revision, 50)
+	}
+
+	revision, httpStatusCode, _ = c.RemoveAppIdentityFromProject(context.Background(), "foo", "my-app")
+	testStatusCode(t, httpStatusCode, 204)
+	if revision != 0 {
+		t.Errorf("RemoveAppIdentityFromProject returned %v, want %v", revision, 0)
+	}
+}
+
+func TestRepositoryRoleAPIs(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	input := map[string]string{"id": "my-app", "role": "WRITE"}
+	mux.HandleFunc("/api/v1/metadata/foo/repos/bar/roles/appIdentities", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		body := map[string]string{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if !reflect.DeepEqual(body, input) {
+			t.Errorf("Request body = %+v, want %+v", body, input)
+		}
+		fmt.Fprint(w, `51`)
+	})
+	mux.HandleFunc("/api/v1/metadata/foo/repos/bar/roles/appIdentities/my-app", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	revision, httpStatusCode, _ := c.AddAppIdentityToRepository(context.Background(), "foo", "bar", "my-app", RepositoryRoleWrite)
+	testStatusCode(t, httpStatusCode, 200)
+	if revision != 51 {
+		t.Errorf("AddAppIdentityToRepository returned %v, want %v", revision, 51)
+	}
+
+	revision, httpStatusCode, _ = c.RemoveAppIdentityFromRepository(context.Background(), "foo", "bar", "my-app")
+	testStatusCode(t, httpStatusCode, 204)
+	if revision != 0 {
+		t.Errorf("RemoveAppIdentityFromRepository returned %v, want %v", revision, 0)
+	}
+}
+
+func TestRemoveAndPurgeAppIdentity(t *testing.T) {
+	c, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v1/appIdentities/my-app", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN"}`)
+	})
+	mux.HandleFunc("/api/v1/appIdentities/my-app/removed", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		fmt.Fprint(w, `{"appId":"my-app","type":"TOKEN"}`)
+	})
+
+	appID, httpStatusCode, _ := c.RemoveAppIdentity(context.Background(), "my-app")
+	testStatusCode(t, httpStatusCode, 200)
+	if appID.AppID != "my-app" {
+		t.Errorf("RemoveAppIdentity returned %+v, want appId my-app", appID)
+	}
+
+	appID, httpStatusCode, _ = c.PurgeAppIdentity(context.Background(), "my-app")
+	testStatusCode(t, httpStatusCode, 200)
+	if appID.AppID != "my-app" {
+		t.Errorf("PurgeAppIdentity returned %+v, want appId my-app", appID)
+	}
+}
+
+func TestAppIdentityRevisionUnmarshalJSON(t *testing.T) {
+	var fromNumber appIdentityRevision
+	if err := json.Unmarshal([]byte(`49`), &fromNumber); err != nil {
+		t.Fatalf("json.Unmarshal(number) error = %v", err)
+	}
+	if int(fromNumber) != 49 {
+		t.Fatalf("fromNumber = %d, want %d", fromNumber, 49)
+	}
+
+	var fromObject appIdentityRevision
+	if err := json.Unmarshal([]byte(`{"revision":50}`), &fromObject); err != nil {
+		t.Fatalf("json.Unmarshal(object) error = %v", err)
+	}
+	if int(fromObject) != 50 {
+		t.Fatalf("fromObject = %d, want %d", fromObject, 50)
+	}
+
+	var invalid appIdentityRevision
+	if err := json.Unmarshal([]byte(`{"rev":51}`), &invalid); err == nil {
+		t.Fatal("json.Unmarshal(invalid) expected error, got nil")
 	}
 }

--- a/consts.go
+++ b/consts.go
@@ -29,10 +29,12 @@ const (
 )
 
 const (
-	projects = "projects"
-	repos    = "repos"
-	contents = "contents"
-	commits  = "commits"
+	projects      = "projects"
+	repos         = "repos"
+	contents      = "contents"
+	metadata      = "metadata"
+	appIdentities = "appIdentities"
+	commits       = "commits"
 
 	actionList    = "list"
 	actionCompare = "compare"

--- a/dogma.go
+++ b/dogma.go
@@ -510,10 +510,65 @@ func (c *Client) CreateAppIdentity(
 	return c.appIdentity.create(ctx, request)
 }
 
+// ListAppIdentities returns app identities.
+func (c *Client) ListAppIdentities(
+	ctx context.Context) (appIdentities []*AppIdentity, httpStatusCode int, err error) {
+	return c.appIdentity.list(ctx)
+}
+
+// RemoveAppIdentity removes an app identity.
+func (c *Client) RemoveAppIdentity(
+	ctx context.Context, appID string) (appIdentity *AppIdentity, httpStatusCode int, err error) {
+	return c.appIdentity.remove(ctx, appID)
+}
+
+// PurgeAppIdentity purges a removed app identity.
+func (c *Client) PurgeAppIdentity(
+	ctx context.Context, appID string) (appIdentity *AppIdentity, httpStatusCode int, err error) {
+	return c.appIdentity.purge(ctx, appID)
+}
+
+// UpdateAppIdentityStatus updates app identity status to active or inactive.
+func (c *Client) UpdateAppIdentityStatus(
+	ctx context.Context, appID string, status AppIdentityStatus) (appIdentity *AppIdentity, httpStatusCode int, err error) {
+	return c.appIdentity.updateStatus(ctx, appID, status)
+}
+
+// UpdateAppIdentityLevel updates app identity level to USER or SYSTEMADMIN.
+func (c *Client) UpdateAppIdentityLevel(
+	ctx context.Context, appID string, level AppIdentityLevel) (appIdentity *AppIdentity, httpStatusCode int, err error) {
+	return c.appIdentity.updateLevel(ctx, appID, level)
+}
+
 // AddAppIdentityToProject adds an app identity to a project with the given role.
 func (c *Client) AddAppIdentityToProject(
 	ctx context.Context, projectName, appID string, role ProjectRole) (revision int, httpStatusCode int, err error) {
 	return c.appIdentity.addToProject(ctx, projectName, appID, role)
+}
+
+// UpdateAppIdentityProjectRole updates app identity role in a project.
+func (c *Client) UpdateAppIdentityProjectRole(
+	ctx context.Context, projectName, appID string, role ProjectRole) (revision int, httpStatusCode int, err error) {
+	return c.appIdentity.updateProjectRole(ctx, projectName, appID, role)
+}
+
+// RemoveAppIdentityFromProject removes an app identity from a project.
+func (c *Client) RemoveAppIdentityFromProject(
+	ctx context.Context, projectName, appID string) (revision int, httpStatusCode int, err error) {
+	return c.appIdentity.removeFromProject(ctx, projectName, appID)
+}
+
+// AddAppIdentityToRepository adds an app identity to a repository with the given role.
+func (c *Client) AddAppIdentityToRepository(
+	ctx context.Context, projectName, repoName, appID string, role RepositoryRole) (
+	revision int, httpStatusCode int, err error) {
+	return c.appIdentity.addToRepository(ctx, projectName, repoName, appID, role)
+}
+
+// RemoveAppIdentityFromRepository removes an app identity from a repository.
+func (c *Client) RemoveAppIdentityFromRepository(
+	ctx context.Context, projectName, repoName, appID string) (revision int, httpStatusCode int, err error) {
+	return c.appIdentity.removeFromRepository(ctx, projectName, repoName, appID)
 }
 
 func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer func()) {

--- a/dogma.go
+++ b/dogma.go
@@ -522,12 +522,6 @@ func (c *Client) RemoveAppIdentity(
 	return c.appIdentity.remove(ctx, appID)
 }
 
-// PurgeAppIdentity purges a removed app identity.
-func (c *Client) PurgeAppIdentity(
-	ctx context.Context, appID string) (appIdentity *AppIdentity, httpStatusCode int, err error) {
-	return c.appIdentity.purge(ctx, appID)
-}
-
 // UpdateAppIdentityStatus updates app identity status to active or inactive.
 func (c *Client) UpdateAppIdentityStatus(
 	ctx context.Context, appID string, status AppIdentityStatus) (appIdentity *AppIdentity, httpStatusCode int, err error) {

--- a/dogma.go
+++ b/dogma.go
@@ -74,10 +74,11 @@ type Client struct {
 	baseURL *url.URL // Base URL for API requests.
 
 	// Services are used to communicate for the different parts of the Central Dogma server API.
-	project    *projectService
-	repository *repositoryService
-	content    *contentService
-	watch      *watchService
+	project     *projectService
+	repository  *repositoryService
+	content     *contentService
+	watch       *watchService
+	appIdentity *appIdentityService
 
 	// metrics
 	metricCollector *metrics.Metrics
@@ -182,6 +183,7 @@ func newClientWithHTTPClient(baseURL *url.URL, client *http.Client) (*Client, er
 	c.repository = (*repositoryService)(service)
 	c.content = (*contentService)(service)
 	c.watch = (*watchService)(service)
+	c.appIdentity = (*appIdentityService)(service)
 	return c, nil
 }
 
@@ -500,6 +502,18 @@ func (c *Client) GetDiffs(ctx context.Context,
 func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision string,
 	commitMessage *CommitMessage, changes []*Change) (result *PushResult, httpStatusCode int, err error) {
 	return c.content.push(ctx, projectName, repoName, baseRevision, commitMessage, changes)
+}
+
+// CreateAppIdentity creates an app identity.
+func (c *Client) CreateAppIdentity(
+	ctx context.Context, request *CreateAppIdentityRequest) (appIdentity *AppIdentity, httpStatusCode int, err error) {
+	return c.appIdentity.create(ctx, request)
+}
+
+// AddAppIdentityToProject adds an app identity to a project with the given role.
+func (c *Client) AddAppIdentityToProject(
+	ctx context.Context, projectName, appID string, role ProjectRole) (revision int, httpStatusCode int, err error) {
+	return c.appIdentity.addToProject(ctx, projectName, appID, role)
 }
 
 func (c *Client) watchWithWatcher(w *Watcher) (result <-chan WatchResult, closer func()) {


### PR DESCRIPTION
This PR adds the following API wrapper for golang client.

- Add new AppIdentity
- Add existing AppIdentity to the specific project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app-identity management to the client, including creating, listing, and removing token/certificate identities.
  * Added identity updates for status and level.
  * Added project and repository assignment support, including role management (owner/member, admin/write/read) with revision tracking.
* **Tests**
  * Consolidated app-identity tests into focused scenarios covering create/list/update and project/repository role flows.
  * Added unit coverage for app-identity revision JSON parsing (number and object forms), including invalid payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->